### PR TITLE
More informative exception information in before_commit

### DIFF
--- a/lib/neo4j-core/event_handler.rb
+++ b/lib/neo4j-core/event_handler.rb
@@ -121,7 +121,7 @@ module Neo4j
         classes_changed(class_change_map)
       rescue Exception => e
         # since these exceptions gets swallowed
-        puts "ERROR in before commit hook #{e}"
+        puts "ERROR in before commit hook: #{e.class} - #{e}"
         puts e.backtrace.join("\n")
       end
 


### PR DESCRIPTION
Hi,

I've been trying out Neo4j and keep seeing `ERROR in before commit hook` somewhat randomly in the logs. I was curious what the underlying issue is so I did some digging. This patch outputs the exception class, which I find helps when the exception has no message. Using this patch, I determined that the error I'm seeing is the following:

```
ERROR in before commit hook: Java::JavaLang::NullPointerException - 
org.neo4j.kernel.impl.nioneo.xa.ReadTransaction.nodeLoadLight(ReadTransaction.java:86)
org.neo4j.kernel.impl.persistence.PersistenceManager.loadLightNode(PersistenceManager.java:82)
org.neo4j.kernel.impl.core.NodeManager.getLightNode(NodeManager.java:423)
org.neo4j.kernel.impl.core.NodeManager.getNodeForProxy(NodeManager.java:440)
org.neo4j.kernel.InternalAbstractGraphDatabase$4.lookup(InternalAbstractGraphDatabase.java:665)
org.neo4j.kernel.impl.core.NodeProxy.hasProperty(NodeProxy.java:160)
...
```

I'm not sure if this is causing problems or not, since everything seems to be working. Any advice?
