### PR TITLE
Thread-safe Neo4j.start

### DIFF
--- a/lib/neo4j/neo4j.rb
+++ b/lib/neo4j/neo4j.rb
@@ -31,15 +31,15 @@ module Neo4j
     # @param [String] config_file (optionally) if this is nil or not given use the Neo4j::Config, otherwise setup the Neo4j::Config file using the provided YAML configuration file.
     # @param [Java::OrgNeo4jKernel::EmbeddedGraphDatabase] external_db (optionally) use this Java Neo4j instead of creating a new neo4j database service.
     def start(config_file=nil, external_db = $NEO4J_SERVER)
-      return if @db && @db.running?
+        return if @db && @db.running?
 
-      Neo4j.config.default_file = config_file if config_file
-      if external_db
-        @db ||= Neo4j::Core::Database.new
-        self.db.start_external_db(external_db)
-      else
-        db.start
-      end
+        Neo4j.config.default_file = config_file if config_file
+        if external_db
+          @db ||= Neo4j::Core::Database.new
+          self.db.start_external_db(external_db)
+        else
+          db.start
+        end
     end
 
 


### PR DESCRIPTION
As discussed in https://github.com/andreasronge/neo4j/issues/237, it seems Neo4j.start is not currently thread-safe. This fix solves the issue for me in both puma and torquebox-lite.

There were two problems:
- There was no lock around `Neo4j::Core::Database#start`, which allowed other threads concurrent access to this method. This fix introduces a lock around the whole method.
- `@running` was set to true in `Neo4j::Core::Database` before the database had actually completed start up. Since other threads check for `db.running?`, this caused these threads to access the database before it had actually completed initializing. This is now fixed by setting `@running` to true only after the database has finished initializing.

It turned out to be unnecessary to put a lock around `Neo4j.start`. In fact, doing so caused problems. (Please ignore the whitespace changes in neo4j.rb - I had trouble cleaning up my git history.)
