### PR TITLE
Make neo4j 1.9.M05 the minimum version

### DIFF
--- a/neo4j-core.gemspec
+++ b/neo4j-core.gemspec
@@ -27,6 +27,6 @@ It comes included with the Apache Lucene document database.
   s.extra_rdoc_files = %w( README.rdoc )
   s.rdoc_options = ["--quiet", "--title", "Neo4j::Core", "--line-numbers", "--main", "README.rdoc", "--inline-source"]
 
-  s.add_dependency("neo4j-community", '>= 1.8.1', '< 1.9')
+  s.add_dependency("neo4j-community", '>=1.9.M05', '<2.0')
   s.add_dependency("neo4j-cypher", '~> 1.0.0')
 end


### PR DESCRIPTION
Not sure if this applies for the community version of neo4j.rb. But neo4j.rb 2.2.4 is incompatible with neo4j 1.8.2 (HA doesn't work). So I'm adding a 1.9.M05 constraint here in the hopes it saves somebody else from figuring this out on his own.

Perhaps there's a better place to do this, though, because community 1.8.2 might work with 2.2.4.
