### PR TITLE
Fix requirement for standalone neo4j-core Gem

### DIFF
--- a/lib/neo4j/property_validator.rb
+++ b/lib/neo4j/property_validator.rb
@@ -1,6 +1,6 @@
 module Neo4j
   module PropertyValidator
-
+    require 'set'
     class InvalidPropertyException < Exception
 
     end


### PR DESCRIPTION
The gem built from the supplied gem spec would cause programs to fail with a:

```
$GEMDIR/neo4j-core-3.0.0.alpha.1/lib/neo4j/property_validator.
rb:9:in `<module:PropertyValidator>': uninitialized constant Neo4j::PropertyValidator::Set (NameError
)
```

The require within the PropertyValidator fixes this.
(ruby 2.1.0-preview2)
