### PR TITLE
Update cypher_translator.rb

### DIFF
--- a/lib/neo4j-core/cypher_translator.rb
+++ b/lib/neo4j-core/cypher_translator.rb
@@ -4,7 +4,7 @@ module Neo4j::Core
     def escape_value(value)
       case value
         when String
-          "'#{value}'" # TODO escape ' and "
+          "'#{value.gsub("'", %q(\\\'))}'"
         else
           value
       end


### PR DESCRIPTION
Why does " need to be escaped? The string in the query seems to be surrounded with ', so " should be fine, no? Atleast in my local test, it worked out fine.
