### PR TITLE
Add support for regex query conditions

### DIFF
--- a/lib/neo4j/label.rb
+++ b/lib/neo4j/label.rb
@@ -86,7 +86,13 @@ module Neo4j
       def condition_to_cypher(query)
         conditions = query[:conditions]
         " WHERE " + conditions.keys.map do |k|
-          "n.#{k}=#{escape_value(conditions[k])}"
+          value = conditions[k]
+          if value.is_a? Regexp
+            pattern = (value.casefold? ? "(?i)" : "") + value.source
+            "n.#{k}=~#{escape_value(pattern.gsub(/\\/, '\\\\\\'))}"           
+          else 
+            "n.#{k}=#{escape_value(conditions[k])}"
+          end
         end.join(" AND ")
       end
 

--- a/spec/shared_examples/label.rb
+++ b/spec/shared_examples/label.rb
@@ -79,6 +79,12 @@ share_examples_for "Neo4j::Label" do
           result.count.should == 2
         end
 
+        it 'supports regex condition' do
+          result = Neo4j::Label.query(@label, conditions: {name: /AND.*/i})
+          result.should include(@andreas1, @andreas2)
+          result.count.should == 2
+        end
+
         it 'returns all nodes if no conditions' do
           result = Neo4j::Label.query(@label, {})
           result.should include(@kalle, @andreas2, @andreas1, @zebbe)


### PR DESCRIPTION
I've added support to query nodes using regexp conditions.
Use .query(@label, conditions: {name: /AND._/i}) to generate ... WHERE n.mydata=~'(?i)AND._' RETURN ID(n)
