### PR TITLE
Allow non-string type properties to survive this workaround

### DIFF
--- a/lib/neo4j-server/cypher_transaction.rb
+++ b/lib/neo4j-server/cypher_transaction.rb
@@ -36,7 +36,7 @@ module Neo4j::Server
 
         # So we have to do this workaround
         params.each_pair do |k,v|
-          statement[:statement].gsub!("{ #{k} }", escape_value(v))
+          statement[:statement].gsub!("{ #{k} }", "#{escape_value(v)}")
         end
       end
       response = HTTParty.post(@exec_url, headers: resource_headers, body: body.to_json)


### PR DESCRIPTION
I discovered this problem while trying to set a new node property to a non-string value, e.g.,

node = Neo4j::Node.new
node[:foo] = 4

Not sure if this is useful (considering the comment above says it's a workaround), but I'll let you make that decision :-)

All the best,
-Shane
