### PR TITLE
add escape sequence sanitization to cypher translator

### DIFF
--- a/lib/neo4j-core/cypher_translator.rb
+++ b/lib/neo4j-core/cypher_translator.rb
@@ -1,14 +1,38 @@
 module Neo4j::Core
   module CypherTranslator
     # Cypher Helper
-    def escape_value(value)
-      case value
-        when String
-          "'#{value.gsub("'", %q(\\\'))}'"
-        else
-          value
-      end
-    end
+     def escape_value(value)
+       result = case value
+         when String
+           sanitized = sanitize_escape_sequences(value)
+           "'#{escape_quotes(sanitized)}'"
+         else
+           value
+       end
+       result
+     end
+
+     # Only following escape sequence characters are allowed in Cypher:
+     #
+     # \t Tab
+     # \b Backspace
+     # \n Newline
+     # \r Carriage return
+     # \f Form feed
+     # \' Single quote
+     # \" Double quote
+     # \\ Backslash
+     #
+     # From:
+     # http://docs.neo4j.org/chunked/stable/cypher-expressions.html#_note_on_string_literals
+     SANITIZE_ESCAPED_REGEXP = /(?<!\\)\\(\\\\)*(?![futbnr'"\\])/
+     def sanitize_escape_sequences(s)
+       s.gsub SANITIZE_ESCAPED_REGEXP, ''
+     end
+
+     def escape_quotes(s)
+       s.gsub("'", %q(\\\'))
+     end
 
     # Cypher Helper
     def cypher_prop_list(props)

--- a/spec/neo4j/cypher_translator_spec.rb
+++ b/spec/neo4j/cypher_translator_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'CypherTranslator' do
+  let(:klass) { Class.new.extend Neo4j::Core::CypherTranslator }
+
+  context '#sanitize_escape_sequences' do
+    context 'with valid strings' do
+      [ 
+        'a\\\\p',
+        'a\b',
+        'a\tb',
+        'a\bb',
+        'a\nb',
+        'a\rb',
+        'a\fb',
+        'a\'b',
+        'a\"b',
+        "a\b",
+        '\u00b5',
+        "\u00b5",
+      ].each do |s|
+        it "does not change #{s}" do
+          klass.sanitize_escape_sequences(s).should == s
+        end
+      end
+    end
+
+    context 'with invalid strings' do
+      {
+        'a\pb'    => 'apb',
+        '2\56'    => '256',
+      }.each do |before, after|
+        it "replaces #{before} with #{after}" do
+          klass.sanitize_escape_sequences(before).should == after
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/shared_examples/node_auto_tx.rb
+++ b/spec/shared_examples/node_auto_tx.rb
@@ -33,6 +33,21 @@ share_examples_for "Neo4j::Node auto tx" do
       end
 
 
+      describe 'broken escape sequence create(name: "ka\putt")' do
+
+        subject do
+          Neo4j::Node.create(name: 'ka\putt')
+        end
+        its(:exist?) { should be_true }
+        its(:neo_id) { should be_a(Fixnum) }
+        its(:props) { should == { name: 'kaputt'} }
+
+        it 'read the properties using []' do
+          subject[:name].should == 'kaputt'
+        end
+      end
+
+
       describe 'load' do
         it "can load a node if it exists" do
           node1 = Neo4j::Node.create


### PR DESCRIPTION
Certain value strings break the cypher queries. Fix is according to: 
http://docs.neo4j.org/chunked/stable/cypher-expressions.html#_note_on_string_literals
