### PR TITLE
Fixing data url in cypher_session for cases where Neo4J doesn't return a...

### DIFF
--- a/lib/neo4j-server/cypher_session.rb
+++ b/lib/neo4j-server/cypher_session.rb
@@ -5,7 +5,9 @@ module Neo4j::Server
     response = HTTParty.get(endpoint_url || 'http://localhost:7474')
     raise "Server not available on #{endpoint_url} (response code #{response.code})" unless response.code == 200
     root_data = JSON.parse(response.body)
-    Neo4j::Server::CypherSession.new(root_data['data'])
+    data_url = root_data['data']
+    data_url << '/' unless data_url.end_with?('/') 
+    Neo4j::Server::CypherSession.new(data_url)
   end
 
   class CypherSession < Neo4j::Session


### PR DESCRIPTION
... trailing slash for the data url in the json

This is how I tried fixing Issue #54

Is there any way that there could be a test written for this? I couldn't find anything similar done in the existing tests, so I didn't add any of my own.

Any feedback on this would be really appreciated.
