### PR TITLE
Neo4j::Label.query: Added limit option

### DIFF
--- a/lib/neo4j/label.rb
+++ b/lib/neo4j/label.rb
@@ -70,6 +70,7 @@ module Neo4j
         cypher += condition_to_cypher(query) if query[:conditions] && !query[:conditions].empty?
         cypher += session.query_default_return
         cypher += order_to_cypher(query) if query[:order]
+        cypher += " LIMIT " + query[:limit].to_s if query[:limit] && query[:limit].is_a?(Integer)
 
         response = session._query_or_fail(cypher)
         session.search_result_to_enumerable(response) # TODO make it work in Embedded and refactor

--- a/spec/shared_examples/label.rb
+++ b/spec/shared_examples/label.rb
@@ -217,6 +217,20 @@ share_examples_for "Neo4j::Label" do
 
       end
 
+      describe 'limit' do
+        it 'limits number of results returned' do
+          result = Neo4j::Label.query(@label, limit: 2)
+          result.count.should == 2
+        end
+
+        it 'limits number of results returned when combined with sort' do
+          result = Neo4j::Label.query(@label, {order: :name, limit: 3})
+          result.to_a.map{|n| n[:name]}.should == %w[andreas andreas kalle]
+          result.count.should == 3
+        end
+      end
+
+
     end
 
   end


### PR DESCRIPTION
Usage:

``` ruby
result = Neo4j::Label.query(@label, {order: :name, limit: 3})
```

Tests included.
