### PR TITLE
Query changes to support orm_adapter pull request

### DIFF
--- a/lib/neo4j/label.rb
+++ b/lib/neo4j/label.rb
@@ -3,6 +3,7 @@ module Neo4j
   # See Neo4j::Node how to create and delete nodes
   # @see http://docs.neo4j.org/chunked/milestone/graphdb-neo4j-labels.html
   class Label
+    class InvalidQueryError < StandardError; end
 
     # @abstract
     def name
@@ -89,8 +90,17 @@ module Neo4j
 
       def cypher_match(label_name, query)
         parts = ["MATCH (n:`#{label_name}`)"]
+
         # TODO: Injection vulnerability?
-        parts += query[:matches] if query[:matches] && !query[:matches].empty?
+        case query[:matches]
+        when Array
+          parts += query[:matches]
+        when String
+          parts << query[:matches]
+        when NilClass
+        else
+          raise InvalidQueryError, "Invalid value for 'matches' query key"
+        end
 
         parts.join(',')
       end

--- a/spec/shared_examples/label.rb
+++ b/spec/shared_examples/label.rb
@@ -185,9 +185,9 @@ share_examples_for "Neo4j::Label" do
           @andreas1 = Neo4j::Node.create({name: 'andreas', age: 1}, @label)
         end
 
-        subject { Neo4j::Label.query(@label, matches: [match], conditions: {name: 'kalle'}) }
+        subject { Neo4j::Label.query(@label, matches: matches, conditions: {name: 'kalle'}) }
 
-        let(:match) { 'n-[:friend]-o' }
+        let(:matches) { ['n-[:friend]-o'] }
         context 'no relationship' do
           its(:count) { should == 0 }
         end
@@ -200,13 +200,32 @@ share_examples_for "Neo4j::Label" do
           it { should include(@kalle) }
 
           context 'correct direction' do
-            let(:match) { 'n-[:friend]->o' }
+            let(:matches) { ['n-[:friend]->o'] }
             it { should include(@kalle) }
           end
 
           context 'incorrect direction' do
-            let(:match) { 'n<-[:friend]-o' }
+            let(:matches) { ['n<-[:friend]-o'] }
             its(:count) { should == 0 }
+          end
+
+          describe 'with string input' do
+            context 'correct direction' do
+              let(:matches) { 'n-[:friend]->o' }
+              it { should include(@kalle) }
+            end
+
+            context 'incorrect direction' do
+              let(:matches) { 'n<-[:friend]-o' }
+              its(:count) { should == 0 }
+            end
+          end
+
+          context 'integer input' do
+            let(:matches) { 1 }
+            it 'raises error' do
+              expect { subject }.to raise_error(Neo4j::Label::InvalidQueryError)
+            end
           end
 
         end


### PR DESCRIPTION
These changes to the neo4j-core query method are to support the changes in this pull request:

https://github.com/andreasronge/neo4j/pull/352

The main change is supporting the :matches key for queries which can be either a string or an array of strings.  I also refactored .cypher_where a bit as I was trying to understand it and because I thought it would be needed for my changes, but I'm not sure they're completely necessary if you don't like them.

Feedback welcome!
