### PR TITLE
switch self.response to response to fix duplicate cypher queries

### DIFF
--- a/lib/neo4j-core/query.rb
+++ b/lib/neo4j-core/query.rb
@@ -155,7 +155,7 @@ module Neo4j::Core
     def each
       response = self.response
       if response.is_a?(Neo4j::Server::CypherResponse)
-        self.response.to_node_enumeration
+        response.to_node_enumeration
       else
         Neo4j::Embedded::ResultWrapper.new(response, self.to_cypher)
       end.each {|object| yield object }


### PR DESCRIPTION
I was troubleshooting some performance issues when I noticed that everything going through Core::Query was being sent to the server twice.

``` ruby
#before

2.1.1 :001 > s = Show.first
#{:headers=>{"Content-Type"=>"application/json", "Accept"=>"application/json"}, :body=>"{\"query\":\"MATCH (n:`Show`) RETURN n ORDER BY ID(n) LIMIT 1\",\"params\":{}}"}
#{:headers=>{"Content-Type"=>"application/json", "Accept"=>"application/json"}, :body=>"{\"query\":\"MATCH (n:`Show`) RETURN n ORDER BY ID(n) LIMIT 1\",\"params\":{}}"}
 => #<Show _classname: "Show", agegroup: 1, cost: "8", created_at: Tue, 15 Sep 2009 05:02:02 +0000, date: Thu, 12 Nov 2009 01:00:00 +0000, fb_link: nil, fb_stats: nil, legacy_id: 7, link_clicks: 0, notes: nil, pmid: "139823399051a91220", tba: nil, ticket_link: nil, time: Thu, 12 Nov 2009 01:00:00 +0000, title: "NOTE THE VENUE CHANGE!", updated_at: Wed, 23 Apr 2014 06:19:50 +0000, verified: true> 
2.1.1 :002 > s.bands.each{|b| puts b.name}
#{:headers=>{"Content-Type"=>"application/json", "Accept"=>"application/json"}, :body=>"{\"query\":\"MATCH (show38625:`Show`), (result:`Band`), show38625\\u003c-[:`Band#shows`]-(result:`Band`) WHERE ID(show38625) = 38625 RETURN result\",\"params\":{}}"}
#{:headers=>{"Content-Type"=>"application/json", "Accept"=>"application/json"}, :body=>"{\"query\":\"MATCH (show38625:`Show`), (result:`Band`), show38625\\u003c-[:`Band#shows`]-(result:`Band`) WHERE ID(show38625) = 38625 RETURN result\",\"params\":{}}"}
#Woe
#Javelina
#The Atlas Moth
#Wetnurse
```

Calls to `self.response` were actually executing the query again, so switching it to the set variable `response` just used what it already had.

``` ruby
#after

2.1.1 :001 > s = Show.first
#{:headers=>{"Content-Type"=>"application/json", "Accept"=>"application/json"}, :body=>"{\"query\":\"MATCH (n:`Show`) RETURN n ORDER BY ID(n) LIMIT 1\",\"params\":{}}"}
 => #<Show _classname: "Show", agegroup: 1, cost: "8", created_at: Tue, 15 Sep 2009 05:02:02 +0000, date: Thu, 12 Nov 2009 01:00:00 +0000, fb_link: nil, fb_stats: nil, legacy_id: 7, link_clicks: 0, notes: nil, pmid: "139823399051a91220", tba: nil, ticket_link: nil, time: Thu, 12 Nov 2009 01:00:00 +0000, title: "NOTE THE VENUE CHANGE!", updated_at: Wed, 23 Apr 2014 06:19:50 +0000, verified: true> 
2.1.1 :002 > s.bands.each{|b| puts b.name}
#{:headers=>{"Content-Type"=>"application/json", "Accept"=>"application/json"}, :body=>"{\"query\":\"MATCH (show38625:`Show`), (result:`Band`), show38625\\u003c-[:`Band#shows`]-(result:`Band`) WHERE ID(show38625) = 38625 RETURN result\",\"params\":{}}"}
#Woe
#Javelina
#The Atlas Moth
#Wetnurse
```

It's a pretty nice performance improvement. ;-)
