### PR TITLE
Fix for node props which are stored in the @props instance variable.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'zip'
 
 group 'development' do
   gem 'yard'
+  gem 'simplecov'
 #  gem 'pry'
 end
 

--- a/lib/neo4j-embedded/embedded_session.rb
+++ b/lib/neo4j-embedded/embedded_session.rb
@@ -23,6 +23,10 @@ module Neo4j::Embedded
       Neo4j::Session.register(self)
     end
 
+    def db_type
+      :embedded_db
+    end
+
     def inspect
       "#{self.class} db_location: '#{@db_location}', running: #{running?}"
     end

--- a/lib/neo4j-embedded/property.rb
+++ b/lib/neo4j-embedded/property.rb
@@ -61,6 +61,10 @@ module Neo4j::Embedded::Property
     get_id
   end
 
+  def refresh
+    # nothing is needed in the embedded db since we always asks the database
+  end
+
   private
 
   def to_ruby_property(key)

--- a/lib/neo4j-server/cypher_session.rb
+++ b/lib/neo4j-server/cypher_session.rb
@@ -37,6 +37,10 @@ module Neo4j::Server
       Neo4j::Session._notify_listeners(:session_available, self)
     end
 
+    def db_type
+      :server_db
+    end
+
     def to_s
       "#{self.class} url: '#{@resource_url}'"
     end

--- a/lib/neo4j/node.rb
+++ b/lib/neo4j/node.rb
@@ -31,6 +31,11 @@ module Neo4j
       raise 'not implemented'
     end
 
+    # Refresh the properties by reading it from the database again next time an property value is requested.
+    def refresh
+      raise 'not implemented'
+    end
+
     # Updates the properties, keeps old properties
     # @param [Hash<Symbol, Object>] properties hash of properties that should be updated on the node
     def update_props(properties)

--- a/lib/neo4j/session.rb
+++ b/lib/neo4j/session.rb
@@ -28,6 +28,11 @@ module Neo4j
       raise "not impl."
     end
 
+    # @return [:embedded_db | :server_db]
+    def db_type
+      raise "not impl."
+    end
+
     def auto_commit?
       true # TODO
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,10 @@ def session
 end
 
 
+def unique_random_number
+  "#{Time.now.year}#{Time.now.to_i}#{Time.now.usec.to_s[0..2]}".to_i
+end
+
 FileUtils.rm_rf(EMBEDDED_DB_PATH)
 
 RSpec.configure do |c|


### PR DESCRIPTION
- All @props keys are now symbols
- Use the cached properties in @props in both get_property and props
- Make it possible to refresh the @props hash
- Refresh is automatically called after updating properties
