### PR TITLE
bump install instructions to 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ require 'neo4j/tasks/neo4j_server'
 
 Install and start neo4j by typing:
 ```
-rake neo4j:install[community-2.1.1]
+rake neo4j:install[community-2.1.3]
 rake neo4j:start
 ```
 


### PR DESCRIPTION
```
rake neo4j:install[community-2.1.1]
Installing Neo4j-community-2.1.1
rake aborted!
community-2.1.1 is not available to download, try a different version
/Users/collin/.rvm/gems/ruby-2.1.1/gems/neo4j-core-3.0.0.alpha.18/lib/neo4j/tasks/neo4j_server.rb:20:in `download_neo4j'
/Users/collin/.rvm/gems/ruby-2.1.1/gems/neo4j-core-3.0.0.alpha.18/lib/neo4j/tasks/neo4j_server.rb:66:in `block (2 levels) in <top (required)>'
/Users/collin/.gem/ruby/1.8/bin/ruby_noexec_wrapper:14:in `eval'
/Users/collin/.gem/ruby/1.8/bin/ruby_noexec_wrapper:14:in `<main>'
Tasks: TOP => neo4j:install
(See full trace by running task with --trace)
```
