### PR TITLE
Revert "adds OR clause and generic cypher method"

### DIFF
--- a/lib/neo4j-core/query.rb
+++ b/lib/neo4j-core/query.rb
@@ -97,7 +97,7 @@ module Neo4j::Core
     # DELETE clause
     # @return [Query]
 
-    METHODS = %w[with start match optional_match using where or set create create_unique merge on_create_set on_match_set remove unwind delete cypher return order skip limit]
+    METHODS = %w[with start match optional_match using where set create create_unique merge on_create_set on_match_set remove unwind delete return order skip limit]
 
     CLAUSES = METHODS.map {|method| const_get(method.split('_').map {|c| c.capitalize }.join + 'Clause') }
 

--- a/lib/neo4j-core/query_clauses.rb
+++ b/lib/neo4j-core/query_clauses.rb
@@ -106,7 +106,7 @@ module Neo4j::Core
         end
 
         def to_cypher(clauses)
-          @keyword.nil? ? clause_string(clauses) : "#{@keyword} #{clause_string(clauses)}"
+          "#{@keyword} #{clause_string(clauses)}"
         end
       end
 
@@ -168,10 +168,6 @@ module Neo4j::Core
     class WhereClause < Clause
       @keyword = 'WHERE'
 
-      def conjunction
-        'AND'
-      end
-
       def from_key_and_value(key, value, previous_keys = [])
         case value
         when Hash
@@ -181,7 +177,7 @@ module Neo4j::Core
             else
               key.to_s + '.' + from_key_and_value(k, v, previous_keys + [key])
             end
-          end.join(" #{conjunction} ")
+          end.join(' AND ')
         when NilClass
           "#{key} IS NULL"
         when Regexp
@@ -195,28 +191,12 @@ module Neo4j::Core
       end
 
       class << self
-        def conjunction
-          'AND'
-        end
-
         def clause_string(clauses)
-          clauses.map(&:value).join(" #{conjunction} ")
+          clauses.map(&:value).join(' AND ')
         end
       end
     end
 
-    class OrClause < WhereClause
-      @keyword = 'OR'
-      def conjunction
-        'OR'
-      end
-
-      class << self
-        def conjunction
-          'OR'
-        end
-      end
-    end
 
     class MatchClause < Clause
       @keyword = 'MATCH'
@@ -504,15 +484,7 @@ module Neo4j::Core
       end
     end
 
-    class CypherClause < Clause
-      @keyword = nil
 
-      class << self
-        def clause_string(clauses)
-          clauses.map(&:value).join
-        end
-      end
-    end
   end
 end
 

--- a/spec/neo4j-core/unit/query_spec.rb
+++ b/spec/neo4j-core/unit/query_spec.rb
@@ -51,14 +51,6 @@ describe Neo4j::Core::Query do
       it_generates "START n MATCH (q:`Person`) WHERE q.age > 30"
     end
 
-    describe ".where('q.age > 30').or('q.height > 6.11').start('n').match(q: Person)" do
-      it_generates "START n MATCH (q:`Person`) WHERE q.age > 30 OR q.height > 6.11"
-    end
-
-    describe ".where('q.age > 30').or('q.height > 6.11').cypher('UNKNOWNCLAUSE Function(q)').start('n').match(q: Person)" do
-      it_generates "START n MATCH (q:`Person`) WHERE q.age > 30 OR q.height > 6.11 UNKNOWNCLAUSE Function(q)"
-    end
-
     describe ".match(q: {age: 30}).set_props(q: {age: 31})" do
       it_generates "MATCH (q {age: 30}) SET q = {age: 31}"
     end
@@ -262,54 +254,6 @@ describe Neo4j::Core::Query do
     end
   end
 
-  # OR
-
-  describe '#or' do
-    describe '.or()' do
-      it_generates ""
-    end
-
-    describe ".or({})" do
-      it_generates ""
-    end
-
-    describe ".or('q.age > 30')" do
-      it_generates "OR q.age > 30"
-    end
-
-    describe ".or('q.age' => 30)" do
-      it_generates "OR q.age = {q_age}", q_age: 30
-    end
-
-    describe ".or('q.age' => [30, 32, 34])" do
-      it_generates "OR q.age IN {q_age}", q_age: [30, 32, 34]
-    end
-
-    describe ".or(q: {age: [30, 32, 34]})" do
-      it_generates "OR q.age IN {q_age}", q_age: [30, 32, 34]
-    end
-
-    describe ".or('q.age' => nil)" do
-      it_generates "OR q.age IS NULL"
-    end
-
-    describe ".or(q: {age: nil})" do
-      it_generates "OR q.age IS NULL"
-    end
-
-    describe ".or(q: {neo_id: 22})" do
-      it_generates "OR ID(q) = 22"
-    end
-
-    describe ".or(q: {age: 30, name: 'Brian'})" do
-      it_generates "OR q.age = {q_age} OR q.name = {q_name}", q_age: 30, q_name: 'Brian'
-    end
-
-    describe ".or(q: {age: 30, name: 'Brian'}).or('r.grade = 80')" do
-      it_generates "OR q.age = {q_age} OR q.name = {q_name} OR r.grade = 80", q_age: 30, q_name: 'Brian'
-    end
-  end
-
   # UNWIND
 
   describe '#unwind' do
@@ -334,13 +278,6 @@ describe Neo4j::Core::Query do
     end
   end
 
-  # CYPHER
-
-  describe '#cypher' do
-    describe '.cypher("WHERE n.age = 40")' do
-      it_generates "WHERE n.age = 40"
-    end
-  end
 
   # RETURN
 


### PR DESCRIPTION
Reverts neo4jrb/neo4j-core#105
I think this might have been a little hasty. "OR" might make more sense used within a string during a `where` clause than as a clause itself.

Still think a generic cypher method would be helpful but I'll think on that.
