### PR TITLE
send initialization params through to Faraday.new

### DIFF
--- a/lib/neo4j-server/cypher_session.rb
+++ b/lib/neo4j-server/cypher_session.rb
@@ -16,7 +16,8 @@ module Neo4j::Server
     # @return [Faraday]
     # @see https://github.com/lostisland/faraday
     def self.create_connection(params)
-      conn = Faraday.new do |b|
+      init_params = params[:initialize] and params.delete(:initialize)
+      conn = Faraday.new(init_params) do |b|
         b.request :basic_auth, params[:basic_auth][:username], params[:basic_auth][:password] if params[:basic_auth]
         b.request :json
         #b.response :logger

--- a/spec/neo4j-server/unit/cypher_session_unit_spec.rb
+++ b/spec/neo4j-server/unit/cypher_session_unit_spec.rb
@@ -118,11 +118,24 @@ module Neo4j::Server
           session = Neo4j::Session.create_session(:server_db, params)
           handlers = session.connection.builder.handlers.map(&:name)
           expect(handlers).to include('Faraday::Request::BasicAuthentication')
-
         end
-
       end
 
+      describe 'with initialization params' do
+        let(:init_params_false) { {initialize: { ssl: { verify: false }}} }
+        let(:init_params_true)  { {initialize: { ssl: { verify: true  }}} }
+        it 'passes the options through to Faraday.new' do
+          base_url = 'http://localhost:7474'
+
+          params = [base_url, init_params_false]
+          session_false = Neo4j::Session.create_session(:server_db, params)
+          expect(session_false.connection.ssl.verify).to be_falsey
+
+          params = [base_url, init_params_true]
+          session_true = Neo4j::Session.create_session(:server_db, params)
+          expect(session_true.connection.ssl.verify).to be_truthy
+        end
+      end
 
       it 'does work with two sessions' do
         base_url = 'http://localhost:7474'


### PR DESCRIPTION
Lets you take advantage of Faraday.new initialization opts. In Neo4j.rb, it looks like this:

`config.neo4j.session_options = { :initialize => { :ssl => { :verify => false }}}`
