### PR TITLE
Sanitize params for when we get weird objects

### DIFF
--- a/lib/neo4j-core/query.rb
+++ b/lib/neo4j-core/query.rb
@@ -315,5 +315,12 @@ module Neo4j::Core
       @merge_params ||= @clauses.compact.inject(@_params) { |params, clause| params.merge(clause.params) }
     end
 
+    def sanitize_params(params)
+      passthrough_classes = [String, Numeric, Array, Regexp]
+      params.each do |key, value|
+        params[key] = value.to_s if not passthrough_classes.any? {|klass| value.is_a?(klass) }
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Was having this problem with importing data from the twitter API.  It sometimes returns Twitter::NullObject objects.  I think that they're built with naught:

https://github.com/avdi/naught

Unfortunately you can't even do object.is_a?(::Twitter::NullObject), but I think that this solution will be nice in general.  Can you think of any other sorts of objects that would go into params aside from these?
