### PR TITLE
Fix double escaping of props

### DIFF
--- a/lib/neo4j-core/cypher_translator.rb
+++ b/lib/neo4j-core/cypher_translator.rb
@@ -9,9 +9,10 @@ module Neo4j::Core
       end
     end
 
+    # Like escape_value but it does not wrap the value in quotes
     def create_escape_value(value)
       if value.is_a?(String) || value.is_a?(Symbol)
-        "#{escape_quotes(sanitize_escape_sequences(value.to_s))}"
+        "#{sanitize_escape_sequences(value.to_s)}"
       else
         value
       end

--- a/spec/neo4j-core/unit/cypher_translator_spec.rb
+++ b/spec/neo4j-core/unit/cypher_translator_spec.rb
@@ -26,6 +26,8 @@ describe Neo4j::Core::CypherTranslator do
         "a\b",
         '\u00b5',
         "\u00b5",
+        'test\\usomething',
+        "D'Amore-Schamberger",
       ].each do |s|
         it "does not change #{s}" do
           expect(klass.sanitize_escape_sequences(s)).to eq(s)

--- a/spec/shared_examples/node_auto_tx.rb
+++ b/spec/shared_examples/node_auto_tx.rb
@@ -8,20 +8,16 @@ RSpec.shared_examples "Neo4j::Node auto tx" do
   context "with auto commit" do
     describe "class methods" do
       describe 'create()' do
+        subject { Neo4j::Node.create }
 
-        subject do
-          Neo4j::Node.create
-        end
         its(:exist?) { should be true }
         its(:neo_id) { should be_a(Fixnum) }
         its(:props) { should == {} }
       end
 
       describe 'create(name: "kalle", age: 42)' do
+        subject { Neo4j::Node.create(name: 'kalle', age: 42) }
 
-        subject do
-          Neo4j::Node.create(name: 'kalle', age: 42)
-        end
         its(:exist?) { should be true }
         its(:neo_id) { should be_a(Fixnum) }
         its(:props) { should == { name: 'kalle', age: 42} }
@@ -32,12 +28,23 @@ RSpec.shared_examples "Neo4j::Node auto tx" do
         end
       end
 
+      describe "create(name: 'D\'Amore-Schamberger')" do
+        subject { Neo4j::Node.create(name: "D'Amore-Schamberger") }
+
+        it { is_expected.to be_persisted }
+        its(:props) { is_expected.to eq({ name: "D'Amore-Schamberger" }) }
+      end
+
+      describe 'create(name: "test\\usomething")' do
+        subject { Neo4j::Node.create(name: "test\\usomething") }
+
+        it { is_expected.to be_persisted }
+        its(:props) { is_expected.to eq({ name: "test\\usomething" }) }
+      end
 
       describe 'create(name: "kalle", age: nil)' do
+        subject { Neo4j::Node.create(name: 'kalle', age: nil) }
 
-        subject do
-          Neo4j::Node.create(name: 'kalle', age: nil)
-        end
         it 'read the properties using []' do
           expect(subject[:name]).to eq('kalle')
           expect(subject[:age]).to be_nil


### PR DESCRIPTION
It looks like properties were being escaped twice on node creation. I noticed this when creating a node with an apostrophe in its name from the Neo4j gem. Corrected and added some extra specs to watch for this.
