### PR TITLE
fix n + 1 node creation, use params in create_rel

### DIFF
--- a/lib/neo4j-server/cypher_relationship.rb
+++ b/lib/neo4j-server/cypher_relationship.rb
@@ -10,8 +10,8 @@ module Neo4j::Server
       @response_hash = value
       @rel_type = @response_hash['type']
       @props = @response_hash['data']
-      @start_node_neo_id = @response_hash['start'].match(/\d+$/)[0].to_i
-      @end_node_neo_id = @response_hash['end'].match(/\d+$/)[0].to_i
+      @start_node_neo_id = @response_hash['start'].is_a?(Integer) ? @response_hash['start'] : @response_hash['start'].match(/\d+$/)[0].to_i
+      @end_node_neo_id = @response_hash['end'].is_a?(Integer) ? @response_hash['end'] : @response_hash['end'].match(/\d+$/)[0].to_i
       @id = @response_hash['id']
     end
 

--- a/lib/neo4j-server/cypher_session.rb
+++ b/lib/neo4j-server/cypher_session.rb
@@ -111,7 +111,9 @@ module Neo4j::Server
     end
 
     def create_node(props = nil, labels = [])
-      CypherNode.new self, _query_or_fail(cypher_string(labels, props), true, cypher_prop_list(props))
+      id = _query_or_fail(cypher_string(labels, props), true, cypher_prop_list(props))
+      value = props.nil? ? id : { 'id' => id, 'metadata' => { 'labels' => labels }, 'data' => props }
+      CypherNode.new(self, value)
     end
 
     def load_node(neo_id)

--- a/spec/neo4j-server/e2e/cypher_transaction_spec.rb
+++ b/spec/neo4j-server/e2e/cypher_transaction_spec.rb
@@ -74,7 +74,7 @@ module Neo4j::Server
         it 'find and can load them' do
           begin
             tx = Neo4j::Transaction.new
-            label_name = unique_random_number
+            label_name = unique_random_number.to_s
             n = Neo4j::Node.create({name: 'andreas'}, label_name)
             found = Neo4j::Label.find_nodes(label_name, :name, "andreas").to_a.first
             expect(found[:name]).to eq('andreas')


### PR DESCRIPTION
All node creations required two queries: one to create the node and return the new ID, the other to get the labels and properties of the node, even though this information was already known to the method in order to create the node in the first place. This instantiates the new CypherNode using this information it already has.
