### PR TITLE
added task for using neo4j-servers start-no-wait

### DIFF
--- a/lib/neo4j/tasks/neo4j_server.rake
+++ b/lib/neo4j/tasks/neo4j_server.rake
@@ -121,6 +121,21 @@ namespace :neo4j do
     end
   end
 
+  desc "Start the Neo4j Server asynchronously"
+  task :start_no_wait, :environment do |_, args|
+    puts "Starting Neo4j #{get_environment(args)}..."
+    if OS::Underlying.windows?
+      if %x[reg query "HKU\\S-1-5-19"].size > 0
+        %x[#{install_location(args)}/bin/Neo4j.bat start-no-wait]  #start service
+      else
+        puts "Starting Neo4j directly, not as a service."
+        %x[#{install_location(args)}/bin/Neo4j.bat]
+      end
+    else
+      %x[#{install_location(args)}/bin/neo4j start-no-wait]
+    end
+  end
+
   desc "Configure Server, e.g. rake neo4j:config[development,8888]"
   task :config, :environment, :port do |_, args|
 


### PR DESCRIPTION
Somehow the standard `rake neo4j:start` task does not work on my machine. Without any error messages the task finishes, but neo4j-server is not started. It just takes too long, i guess.
However using `./db/neo4j/development/bin/neo4j start-no-wait` works perfectly. This is the rake task for it; usage: `rake neo4j:start_no_wait`
