### PR TITLE
initialize faraday with the url

### DIFF
--- a/lib/neo4j-server/cypher_session.rb
+++ b/lib/neo4j-server/cypher_session.rb
@@ -23,9 +23,9 @@ module Neo4j
       # @param [Hash] params could be empty or contain basic authentication user and password
       # @return [Faraday]
       # @see https://github.com/lostisland/faraday
-      def self.create_connection(params)
+      def self.create_connection(params, url = nil)
         init_params = params[:initialize] && params.delete(:initialize)
-        conn = Faraday.new(init_params) do |b|
+        conn = Faraday.new(url, init_params) do |b|
           b.request :basic_auth, params[:basic_auth][:username], params[:basic_auth][:password] if params[:basic_auth]
           b.request :json
           # b.response :logger
@@ -45,8 +45,8 @@ module Neo4j
       # @param [Hash] params faraday params, see #create_connection or an already created faraday connection
       def self.open(endpoint_url = nil, params = {})
         extract_basic_auth(endpoint_url, params)
-        connection = params[:connection] || create_connection(params)
         url = endpoint_url || 'http://localhost:7474'
+        connection = params[:connection] || create_connection(params, url)
         auth_obj = CypherAuthentication.new(url, connection, params)
         auth_obj.authenticate
         response = connection.get(url)

--- a/lib/neo4j/node.rb
+++ b/lib/neo4j/node.rb
@@ -123,11 +123,6 @@ module Neo4j
       fail 'not implemented'
     end
 
-    # @return all the Neo4j labels for this node
-    def labels
-      fail 'not implemented'
-    end
-
     # Returns the only node of a given type and direction that is attached to this node, or nil.
     # This is a convenience method that is used in the commonly occuring situation where a node has exactly zero or one relationships of a given type and direction to another node.
     # Typically this invariant is maintained by the rest of the code: if at any time more than one such relationships exist, it is a fatal error that should generate an exception.
@@ -157,11 +152,6 @@ module Neo4j
     # Returns true or false if there is one or more relationships
     # @return [Boolean]
     def rel?(spec = {})
-      fail 'not implemented'
-    end
-
-    # @return [Boolean] true if the node exists
-    def exist?
       fail 'not implemented'
     end
 

--- a/spec/neo4j-core/unit/session_unit_spec.rb
+++ b/spec/neo4j-core/unit/session_unit_spec.rb
@@ -4,13 +4,12 @@ describe Neo4j::Session do
   let(:session) { Neo4j::Session.new }
   let(:error) { 'not impl.' }
   it 'raises errors for methods not implemented' do
-    [lambda { session.start }, lambda { session.shutdown }, lambda { session.db_type }, lambda { session.begin_tx }].each do |l|
+    [-> { session.start }, -> { session.shutdown }, -> { session.db_type }, -> { session.begin_tx }].each do |l|
       expect { l.call }.to raise_error error
     end
 
     expect { session.query }.to raise_error 'not implemented, abstract'
     expect { session._query }.to raise_error 'not implemented'
     expect { create_session(:foo) }.to raise_error
-
   end
 end

--- a/spec/neo4j-core/unit/session_unit_spec.rb
+++ b/spec/neo4j-core/unit/session_unit_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Neo4j::Session do
+  let(:session) { Neo4j::Session.new }
+  let(:error) { 'not impl.' }
+  it 'raises errors for methods not implemented' do
+    [lambda { session.start }, lambda { session.shutdown }, lambda { session.db_type }, lambda { session.begin_tx }].each do |l|
+      expect { l.call }.to raise_error error
+    end
+
+    expect { session.query }.to raise_error 'not implemented, abstract'
+    expect { session._query }.to raise_error 'not implemented'
+    expect { create_session(:foo) }.to raise_error
+
+  end
+end

--- a/spec/neo4j-server/e2e/cypher_session_spec.rb
+++ b/spec/neo4j-server/e2e/cypher_session_spec.rb
@@ -33,6 +33,12 @@ module Neo4j
           expect(connection).to receive(:get).at_least(:once).and_call_original
           Neo4j::Session.open(:server_db, 'http://localhost:7474',  connection: connection)
         end
+
+        it 'adds host and port to the connection object' do
+          connection = Neo4j::Session.current.connection
+          expect(connection.port).to eq 7474
+          expect(connection.host).to eq 'localhost'
+        end
       end
 
 

--- a/spec/neo4j-server/rest/create_node_spec.rb
+++ b/spec/neo4j-server/rest/create_node_spec.rb
@@ -5,13 +5,18 @@ def url_for(rel_url)
 end
 
 cypher_url = 'http://localhost:7474/db/data/cypher'
-resource_headers = {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
 
 describe 'Cypher Queries', api: :server do
   describe 'CREATE (v1) RETURN ID(v1)' do
     it 'returns correct response' do
       body = {query: 'CREATE (v1) RETURN ID(v1)'}.to_json
-      response = HTTParty.send(:post, cypher_url, headers: resource_headers, body: body)
+      response_body = Faraday.new.post do |p|
+        p.url cypher_url
+        p.headers['Content-Type'] = 'application/json'
+        p.headers['Accept'] = 'application/json'
+        p.body = body
+      end.body
+      response = JSON.parse(response_body)
       expect(response['columns']).to eq(['ID(v1)'])
       id = response['data'].first.first
       expect(id).to be_a(Fixnum)


### PR DESCRIPTION
Doing this makes the connection object more reusable, since it knows the basics of the established session. You can still override it by passing a full url to any connection.get or connection.post, but if you want to do connection.get('/some/relative/path'), you're able to. This is especially useful for communicating with REST endpoints provided by unmanaged extensions.