### PR TITLE
Object allocation

### DIFF
--- a/lib/neo4j-core/query.rb
+++ b/lib/neo4j-core/query.rb
@@ -258,19 +258,21 @@ module Neo4j
       #    Query.new.match(p: :Person).where(p: {age: 30})  # => "MATCH (p:Person) WHERE p.age = 30
       #
       # @return [String] Resulting cypher query string
+      EMPTY = ' '
       def to_cypher
-        cypher_string = partitioned_clauses.map do |clauses|
+        cypher_string = partitioned_clauses.map! do |clauses|
           clauses_by_class = clauses.group_by(&:class)
 
           cypher_parts = CLAUSES.map do |clause_class|
             clause_class.to_cypher(clauses) if clauses = clauses_by_class[clause_class]
           end
 
-          cypher_parts.compact.join(' ').strip
-        end.join ' '
+          cypher_parts.compact!
+          cypher_parts.join(EMPTY).tap(&:strip!)
+        end.join EMPTY
 
         cypher_string = "CYPHER #{@options[:parser]} #{cypher_string}" if @options[:parser]
-        cypher_string.strip
+        cypher_string.tap(&:strip!)
       end
 
       # Returns a CYPHER query specifying the union of the callee object's query and the argument's query
@@ -356,7 +358,8 @@ module Neo4j
       end
 
       def merge_params
-        @merge_params ||= @clauses.compact.inject(@_params) { |params, clause| params.merge(clause.params) }
+        @clauses.compact!
+        @merge_params ||= @clauses.inject(@_params) { |params, clause| params.merge!(clause.params) }
       end
 
       def sanitize_params(params)

--- a/lib/neo4j-server/cypher_node.rb
+++ b/lib/neo4j-server/cypher_node.rb
@@ -198,7 +198,8 @@ module Neo4j
         end
       end
 
-      def ensure_single_relationship(&block)
+      def ensure_single_relationship
+        fail 'Expected a block' unless block_given?
         result = yield
         fail "Expected to only find one relationship from node #{neo_id} matching #{match.inspect} but found #{result.count}" if result.count > 1
         result.first

--- a/lib/neo4j-server/cypher_response.rb
+++ b/lib/neo4j-server/cypher_response.rb
@@ -36,7 +36,7 @@ module Neo4j
           "Enumerable query: '#{@query}'"
         end
 
-        def each(&block)
+        def each
           @response.each_data_row do |row|
             yield struct_rows(row)
           end

--- a/lib/neo4j-server/cypher_session.rb
+++ b/lib/neo4j-server/cypher_session.rb
@@ -234,15 +234,13 @@ module Neo4j
         end
       end
 
-      def self.log_with(&block)
+      EMPTY = ''
+      def self.log_with
         clear, yellow, cyan = %W(\e[0m \e[33m \e[36m)
-
         ActiveSupport::Notifications.subscribe('neo4j.cypher_query') do |_, start, finish, _id, payload|
           ms = (finish - start) * 1000
-
-          params_string = (payload[:params].size > 0 ? ' | ' + payload[:params].inspect : '')
-
-          block.call(" #{cyan}#{payload[:context]}#{clear} #{yellow}#{ms.round}ms#{clear} #{payload[:cypher]}" + params_string)
+          params_string = (payload[:params].size > 0 ? "| #{payload[:params].inspect}" : EMPTY)
+          yield(" #{cyan}#{payload[:context]}#{clear} #{yellow}#{ms.round}ms#{clear} #{payload[:cypher]} #{params_string}")
         end
       end
     end


### PR DESCRIPTION
Mostly using `!` methods to modify in place where possible. It can cut a couple dozen objects during each Query. Drops in the pond but it adds up. Also removed a few explicit `&block` params when `yield` was possible.