### PR TITLE
remove :: from params

### DIFF
--- a/lib/neo4j-core/query_clauses.rb
+++ b/lib/neo4j-core/query_clauses.rb
@@ -179,7 +179,7 @@ module Neo4j
             if value.to_s.match(/^{.+}$/)
               "#{key}: #{value}"
             else
-              param_key = "#{prefix}#{key}".tap { |s| s.gsub!('::', '_') }
+              param_key = "#{prefix}#{key}".gsub('::', '_')
               @params[param_key.to_sym] = value
               "#{key}: {#{param_key}}"
             end

--- a/lib/neo4j-core/query_clauses.rb
+++ b/lib/neo4j-core/query_clauses.rb
@@ -179,7 +179,7 @@ module Neo4j
             if value.to_s.match(/^{.+}$/)
               "#{key}: #{value}"
             else
-              param_key = prefix + key.to_s
+              param_key = "#{prefix}#{key}".tap { |s| s.gsub!('::', '_') }
               @params[param_key.to_sym] = value
               "#{key}: {#{param_key}}"
             end


### PR DESCRIPTION
This was causing problems with `merge` in the Neo4j gem when a class's name included `::`.