### PR TITLE
add ConstraintError class + small rubocop refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ script:
   - "bundle exec rake neo4j:install[$NEO4J_VERSION] neo4j:disable_auth neo4j:start default --trace"
 language: ruby
 rvm:
-  - 2.2.0
+  - 2.2.2
   - 2.1.5
-  - jruby-1.7.16
+  - jruby-1.7.18
   # - jruby-19mode
 env:
   - NEO4J_VERSION=community-2.2.1
   - NEO4J_VERSION=community-2.1.7
+sudo: false

--- a/lib/neo4j-server/cypher_response.rb
+++ b/lib/neo4j-server/cypher_response.rb
@@ -13,7 +13,7 @@ module Neo4j
         end
       end
 
-      class ConstraintError < ResponseError; end
+      class ConstraintViolationError < ResponseError; end
 
       class HashEnumeration
         include Enumerable
@@ -205,7 +205,7 @@ module Neo4j
       CONSTRAINT_ERROR = 'Neo.ClientError.Schema.ConstraintViolation'
       def raise_error
         fail 'Tried to raise error without an error' unless @error
-        error_class = constraint_error? ? ConstraintError : ResponseError
+        error_class = constraint_error? ? ConstraintViolationError : ResponseError
         fail error_class.new(@error_msg, @error_status, @error_code)
       end
 

--- a/spec/neo4j-server/unit/cypher_response_unit_spec.rb
+++ b/spec/neo4j-server/unit/cypher_response_unit_spec.rb
@@ -213,6 +213,12 @@ module Neo4j
           it { is_expected.to be_truthy }
         end
       end
+
+      describe 'CypherResponse::ConstraintError' do
+        it 'inherits from ResponseError' do
+          expect(CypherResponse::ConstraintError.new(nil, nil, nil)).to be_a(CypherResponse::ResponseError)
+        end
+      end
     end
   end
 end

--- a/spec/neo4j-server/unit/cypher_response_unit_spec.rb
+++ b/spec/neo4j-server/unit/cypher_response_unit_spec.rb
@@ -214,9 +214,9 @@ module Neo4j
         end
       end
 
-      describe 'CypherResponse::ConstraintError' do
+      describe 'CypherResponse::ConstraintViolationError' do
         it 'inherits from ResponseError' do
-          expect(CypherResponse::ConstraintError.new(nil, nil, nil)).to be_a(CypherResponse::ResponseError)
+          expect(CypherResponse::ConstraintViolationError.new(nil, nil, nil)).to be_a(CypherResponse::ResponseError)
         end
       end
     end

--- a/spec/shared_examples/label.rb
+++ b/spec/shared_examples/label.rb
@@ -246,9 +246,9 @@ RSpec.shared_examples 'Neo4j::Label' do
       Neo4j::Session.current.query.match('(n:MyFoo)').delete(:n).exec
     end
 
-    it 'raises a ConstraintError' do
+    it 'raises a ConstraintViolationError' do
       expect { Neo4j::Node.create({bar: 'dawn'}, :MyFoo) }.not_to raise_error
-      expect { Neo4j::Node.create({bar: 'dawn'}, :MyFoo) }.to raise_error { Neo4j::Server::CypherResponse::ConstraintError }
+      expect { Neo4j::Node.create({bar: 'dawn'}, :MyFoo) }.to raise_error { Neo4j::Server::CypherResponse::ConstraintViolationError }
     end
   end
 


### PR DESCRIPTION
This adds a `ConstraintError` class that inherits from `ResponseError`. Constraint errors happen all the time and it's not a big deal, so it should be easier to spot and recover from them in a way that's different from normal Cypher errors. It inherits so that those already recovering from `ResponseError` can keep on truckin'.