### PR TITLE
split the url instead of regex match to find rel node ids

### DIFF
--- a/lib/neo4j-server/cypher_relationship.rb
+++ b/lib/neo4j-server/cypher_relationship.rb
@@ -127,7 +127,7 @@ module Neo4j
       end
 
       def neo_id_integer(id_or_url)
-        id_or_url.is_a?(Integer) ? id_or_url : id_or_url.match(/\d+$/)[0].to_i
+        id_or_url.is_a?(Integer) ? id_or_url : id_or_url.split('/').last.to_i
       end
     end
   end


### PR DESCRIPTION
One of those "nobody-will-ever-notice-this-tiny-performance-improvement" fixes but... it was bugging me.