### PR TITLE
Simplify server db in jruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - 2015-12-24
+
+### Fixed
+
+- There is no longer a need to know about / use the `WITHOUT_NEO4J_EMBEDDED` environment variable if you want to use server mode in jRuby.
+
 ## [6.0.4] - 2015-12-22
 
 ### Fixed

--- a/lib/neo4j-core.rb
+++ b/lib/neo4j-core.rb
@@ -23,4 +23,3 @@ require 'neo4j/transaction'
 
 require 'rake'
 require 'neo4j/rake_tasks'
-

--- a/lib/neo4j-core.rb
+++ b/lib/neo4j-core.rb
@@ -21,8 +21,8 @@ require 'neo4j/ansi'
 require 'neo4j/relationship'
 require 'neo4j/transaction'
 
-require 'rake'
-require 'neo4j/rake_tasks'
+
+require 'neo4j-server'
 
 if RUBY_PLATFORM != 'java'
   # just for the tests
@@ -31,3 +31,7 @@ if RUBY_PLATFORM != 'java'
     end
   end
 end
+
+
+require 'rake'
+require 'neo4j/rake_tasks'

--- a/lib/neo4j-core.rb
+++ b/lib/neo4j-core.rb
@@ -21,14 +21,10 @@ require 'neo4j/ansi'
 require 'neo4j/relationship'
 require 'neo4j/transaction'
 
-require 'neo4j-server'
-
 require 'rake'
 require 'neo4j/rake_tasks'
 
-if RUBY_PLATFORM == 'java' && !ENV['WITHOUT_NEO4J_EMBEDDED']
-  require 'neo4j-embedded'
-else
+if RUBY_PLATFORM != 'java'
   # just for the tests
   module Neo4j
     module Embedded

--- a/lib/neo4j-core.rb
+++ b/lib/neo4j-core.rb
@@ -21,17 +21,6 @@ require 'neo4j/ansi'
 require 'neo4j/relationship'
 require 'neo4j/transaction'
 
-
-require 'neo4j-server'
-
-if RUBY_PLATFORM != 'java'
-  # just for the tests
-  module Neo4j
-    module Embedded
-    end
-  end
-end
-
-
 require 'rake'
 require 'neo4j/rake_tasks'
+

--- a/lib/neo4j/session.rb
+++ b/lib/neo4j/session.rb
@@ -98,10 +98,7 @@ module Neo4j
       # @param [String] endpoint_url The path to the server, either a URL or path to embedded DB
       # @param [Hash] params Additional configuration options
       def open(db_type = :server_db, endpoint_url = nil, params = {})
-        case db_type
-        when :server_db then require 'neo4j-server'
-        when :embedded_db then require 'neo4j-embedded'
-        end
+        require 'neo4j-embedded' if db_type == :embedded_db
 
         validate_session_num!(db_type)
         name = params[:name]

--- a/lib/neo4j/session.rb
+++ b/lib/neo4j/session.rb
@@ -98,6 +98,11 @@ module Neo4j
       # @param [String] endpoint_url The path to the server, either a URL or path to embedded DB
       # @param [Hash] params Additional configuration options
       def open(db_type = :server_db, endpoint_url = nil, params = {})
+        case db_type
+        when :server_db then require 'neo4j-server'
+        when :embedded_db then require 'neo4j-embedded'
+        end
+
         validate_session_num!(db_type)
         name = params[:name]
         default = params[:default]

--- a/lib/neo4j/session.rb
+++ b/lib/neo4j/session.rb
@@ -98,7 +98,10 @@ module Neo4j
       # @param [String] endpoint_url The path to the server, either a URL or path to embedded DB
       # @param [Hash] params Additional configuration options
       def open(db_type = :server_db, endpoint_url = nil, params = {})
-        require 'neo4j-embedded' if db_type == :embedded_db
+        case db_type
+        when :server_db then require 'neo4j-server'
+        when :embedded_db then require 'neo4j-embedded'
+        end
 
         validate_session_num!(db_type)
         name = params[:name]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ require 'tmpdir'
 require 'logger'
 require 'rspec/its'
 require 'neo4j-core'
+require 'neo4j-server'
+require 'neo4j-embedded' if RUBY_PLATFORM == 'java'
 require 'ostruct'
 
 if RUBY_PLATFORM == 'java'
@@ -35,6 +37,7 @@ if RUBY_PLATFORM == 'java'
       send(key)
     end
   end
+
 end
 
 Dir["#{File.dirname(__FILE__)}/shared_examples/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
So that you don't need to know to specify the `WITHOUT_NEO4J_EMBEDDED` environment variable to use `server_db` in jRuby.

Inspired by http://stackoverflow.com/questions/34445227/logstash-custom-plugin-unable-to-create-session-to-neo4j-within-logstash/34446192#34446192