### PR TITLE
Support Ruby 2.2.4 and 2.3.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ script:
   - "export JRUBY_OPTS='-X+O -J-Djruby.launch.inproc=false -J-Xmx1024m -J-XX:MaxPermSize=2048m' && travis_retry bundle exec rake neo4j:install[$NEO4J_VERSION] neo4j:disable_auth neo4j:start --trace && rspec --tag $RSPEC_TAGS"
 language: ruby
 rvm:
+  - 2.3.0
   - 2.2.4
   - 2.1.5
   - jruby-1.7.23
@@ -14,19 +15,19 @@ sudo: false
 matrix:
   include:
     # Pre-2.1.5 is special, metadata isn't sent back with HTTP REST endpoint
-    - rvm: 2.2.4
+    - rvm: 2.3.0
       env: RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.1.4
 
     # Sanity check against Neo4j 2.3.x with MRI and JRuby
-    - rvm: 2.2.4
+    - rvm: 2.3.0
       env: RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.3.0
     - rvm: jruby-9.0.0.0
       env: RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.3.0
 
     # Testing new CypherSession
-    - rvm: 2.2.4
+    - rvm: 2.3.0
       env: RSPEC_TAGS=new_cypher_session NEO4J_VERSION=community-2.2.5
-    - rvm: 2.2.4
+    - rvm: 2.3.0
       env: RSPEC_TAGS=new_cypher_session NEO4J_VERSION=community-2.1.4
     - rvm: jruby-9.0.0.0
       env: RSPEC_TAGS=new_cypher_session NEO4J_VERSION=community-2.2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
   - "export JRUBY_OPTS='-X+O -J-Djruby.launch.inproc=false -J-Xmx1024m -J-XX:MaxPermSize=2048m' && travis_retry bundle exec rake neo4j:install[$NEO4J_VERSION] neo4j:disable_auth neo4j:start --trace && rspec --tag $RSPEC_TAGS"
 language: ruby
 rvm:
-  - 2.2.3
+  - 2.2.4
   - 2.1.5
   - jruby-1.7.23
   - jruby-9.0.0.0
@@ -14,19 +14,19 @@ sudo: false
 matrix:
   include:
     # Pre-2.1.5 is special, metadata isn't sent back with HTTP REST endpoint
-    - rvm: 2.2.3
+    - rvm: 2.2.4
       env: RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.1.4
 
     # Sanity check against Neo4j 2.3.x with MRI and JRuby
-    - rvm: 2.2.3
+    - rvm: 2.2.4
       env: RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.3.0
     - rvm: jruby-9.0.0.0
       env: RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.3.0
 
     # Testing new CypherSession
-    - rvm: 2.2.3
+    - rvm: 2.2.4
       env: RSPEC_TAGS=new_cypher_session NEO4J_VERSION=community-2.2.5
-    - rvm: 2.2.3
+    - rvm: 2.2.4
       env: RSPEC_TAGS=new_cypher_session NEO4J_VERSION=community-2.1.4
     - rvm: jruby-9.0.0.0
       env: RSPEC_TAGS=new_cypher_session NEO4J_VERSION=community-2.2.5


### PR DESCRIPTION
I have set the configuration of the matrix to Ruby 2.3.0 .

I looked at https://github.com/neo4jrb/neo4j/pull/1089 . I thought it was necessary to 2.2.x until 2.3.1 is released , I added configure of Ruby 2.2.4.