### PR TITLE
simplifies transaction response parse, fixes path/nodes bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Returning paths within transactions in Server mode could result in incorrectly wrapped nodes.
+
 ## [6.1.0] - 2016-01-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Returning paths within transactions in Server mode could result in incorrectly wrapped nodes.
 
+### Changed
+
+- The process of parsing responses from the transactional endpoint was simplified and improved. A few methods tied directly to the old implementation and with no reusability were removed. See https://github.com/neo4jrb/neo4j-core/pull/249 for changes.
+
 ## [6.1.0] - 2016-01-01
 
 ### Fixed

--- a/lib/neo4j-server/cypher_response.rb
+++ b/lib/neo4j-server/cypher_response.rb
@@ -180,7 +180,9 @@ module Neo4j
         end
       end
 
-
+      def transaction_response?
+        response.respond_to?(:body) && !response.body[:commit].nil?
+      end
 
       def set_data(response)
         @data = response[:data]

--- a/spec/neo4j-server/unit/cypher_response_unit_spec.rb
+++ b/spec/neo4j-server/unit/cypher_response_unit_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-
+# rubocop:disable Metrics/ModuleLength
 module Neo4j
   module Server
     describe CypherResponse do
@@ -219,6 +219,24 @@ module Neo4j
           expect(CypherResponse::ConstraintViolationError.new(nil, nil, nil)).to be_a(CypherResponse::ResponseError)
         end
       end
+
+      describe '#transaction_response?' do
+        let(:response) { Neo4j::Server::CypherResponse.new(http_double) }
+        let(:http_double) { double('An HTTP result', body: body_hash) }
+        subject { response.transaction_response? }
+
+        context 'with transaction keys' do
+          let(:body_hash) { {commit: 'foo'} }
+          it { is_expected.to eq true }
+        end
+
+        context 'without transaction keys' do
+          let(:body_hash) { {} }
+
+          it { is_expected.to eq false }
+        end
+      end
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
This fixes https://github.com/neo4jrb/neo4j/issues/1125 and, in the process, simplifies our handling of responses from transactions.

Neo4j Server provides different JSON formats. When returning data from the legacy Cypher endpoint, you get an arrays of data in what they call REST format, which contains everything we need: `metadata` (labels, type, id) and `properties`. When returning from the transactional endpoint, you get... I don't remember what the default is called, but it doesn't give us what we need, so we also tell it to include the REST format separately. The result is two keys, one containing the default transaction response, the other containing the more complete response.

What we were doing was complicated. We were looking for transaction responses and then keeping track of how far along we were in a loop through the default, insufficient data, and then supplementing it with data from the other, complete REST representation. This could lead to weird problems when things didn't map as expected, like when returning paths.

The solution is really simple: as soon as possible, figure out if you're dealing with a transaction. If so, just work entirely from the REST representation and ignore the weak transaction response entirely. It simplifies a lot of code and fixes the original problem.