### PR TITLE
Remove the dependency on HTTParty.

### DIFF
--- a/neo4j-core.gemspec
+++ b/neo4j-core.gemspec
@@ -24,7 +24,6 @@ Neo4j-core provides classes and methods to work with the graph database Neo4j.
   s.extra_rdoc_files = %w( README.md )
   s.rdoc_options = ['--quiet', '--title', 'Neo4j::Core', '--line-numbers', '--main', 'README.rdoc', '--inline-source']
 
-  s.add_dependency('httparty')
   s.add_dependency('faraday', '~> 0.9.0')
   s.add_dependency('net-http-persistent')
   s.add_dependency('httpclient')


### PR DESCRIPTION
This pull removes the httparty gem as a dependency.

Pings:
@cheerfulstoic
@subvertallchris

It appears to be an artifact from before Faraday was used.

Sorry to be a party pooper.