### PR TITLE
Implement Neo4j 3 `CALL` clause

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.3.1
   - 2.2.5
   - jruby-1.7.23
-  - jruby-9.0.0.0
+  - jruby-9.0.5.0
 env:
   - RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.3.0
   - RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.2.6
@@ -12,22 +12,22 @@ sudo: false
 matrix:
   include:
     - script: "bundle exec rubocop"
-      rvm: 2.3.0
+      rvm: 2.3.1
       env: "RUBOCOP=true"
     # Pre-2.1.5 is special, metadata isn't sent back with HTTP REST endpoint
-    - rvm: 2.3.0
+    - rvm: 2.3.1
       env: RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.1.8
 
     # Sanity check against Neo4j 2.3.x with MRI and JRuby
-    - rvm: 2.3.0
+    - rvm: 2.3.1
       env: RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.3.0
-    - rvm: jruby-9.0.0.0
+    - rvm: jruby-9.0.4.0
       env: RSPEC_TAGS=~new_cypher_session NEO4J_VERSION=community-2.3.0
 
     # Testing new CypherSession
-    - rvm: 2.3.0
+    - rvm: 2.3.1
       env: RSPEC_TAGS=new_cypher_session NEO4J_VERSION=community-2.2.5
-    - rvm: 2.3.0
+    - rvm: 2.3.1
       env: RSPEC_TAGS=new_cypher_session NEO4J_VERSION=community-2.1.8
-    - rvm: jruby-9.0.0.0
+    - rvm: jruby-9.0.4.0
       env: RSPEC_TAGS=new_cypher_session NEO4J_VERSION=community-2.2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 script: "export JRUBY_OPTS='-X+O -J-Djruby.launch.inproc=false -J-Xmx1024m -J-XX:MaxPermSize=2048m' && travis_retry bundle exec rake neo4j:install[$NEO4J_VERSION] neo4j:disable_auth neo4j:start --trace && rspec --tag $RSPEC_TAGS"
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.2.4
+  - 2.3.1
+  - 2.2.5
   - jruby-1.7.23
   - jruby-9.0.0.0
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,18 @@ gem 'activesupport', '~> 4.2' if RUBY_VERSION.to_f < 2.2
 
 group 'development' do
   gem 'guard-rspec', require: false
-  gem 'overcommit'
+  if RUBY_VERSION.to_f < 2.0
+    gem 'overcommit', '< 0.35.0'
+  else
+    gem 'overcommit'
+  end
 end
 
 group 'test' do
   gem 'coveralls', require: false
   gem 'simplecov-html', require: false
+  gem 'tins', '< 1.7' if RUBY_VERSION.to_f < 2.0
+  gem 'ruby_dep', '< 1.4'
   gem 'rspec', '~> 3.0'
   gem 'rspec-its'
   gem 'dotenv'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem 'activesupport', '~> 4.2' if RUBY_VERSION.to_f < 2.2
 
 group 'development' do
+  gem 'listen', '< 3.1'
   gem 'guard-rspec', require: false
   if RUBY_VERSION.to_f < 2.0
     gem 'overcommit', '< 0.35.0'
@@ -20,7 +21,6 @@ group 'test' do
   gem 'coveralls', require: false
   gem 'simplecov-html', require: false
   gem 'tins', '< 1.7' if RUBY_VERSION.to_f < 2.0
-  gem 'ruby_dep', '< 1.4'
   gem 'rspec', '~> 3.0'
   gem 'rspec-its'
   gem 'dotenv'

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gemspec
 # gem 'neo4j-advanced',   '>= 1.8.1', '< 2.0', :require => false
 # gem 'neo4j-enterprise', '>= 1.8.1', '< 2.0', :require => false
 
+gem 'activesupport', '~> 4.2' if RUBY_VERSION.to_f < 2.2
+
 group 'development' do
   gem 'guard-rspec', require: false
   gem 'overcommit'

--- a/lib/neo4j-core/query.rb
+++ b/lib/neo4j-core/query.rb
@@ -158,11 +158,10 @@ module Neo4j
       # DETACH DELETE clause
       # @return [Query]
 
-      METHODS = %w(start match optional_match using where create create_unique merge set on_create_set on_match_set remove unwind delete detach_delete with return order skip limit)
-      BREAK_METHODS = %(with)
+      METHODS = %w(start match optional_match call using where create create_unique merge set on_create_set on_match_set remove unwind delete detach_delete with return order skip limit) # rubocop:disable Metrics/LineLength
+      BREAK_METHODS = %(with call)
 
       CLAUSIFY_CLAUSE = proc { |method| const_get(method.to_s.split('_').map(&:capitalize).join + 'Clause') }
-
       CLAUSES = METHODS.map(&CLAUSIFY_CLAUSE)
 
       METHODS.each_with_index do |clause, i|

--- a/lib/neo4j-core/query_clauses.rb
+++ b/lib/neo4j-core/query_clauses.rb
@@ -337,6 +337,24 @@ module Neo4j
         end
       end
 
+      class CallClause < Clause
+        KEYWORD = 'CALL'
+
+        def from_string(value)
+          value
+        end
+
+        class << self
+          def clause_strings(clauses)
+            clauses.map!(&:value)
+          end
+
+          def clause_join
+            " #{KEYWORD} "
+          end
+        end
+      end
+
       class MatchClause < Clause
         KEYWORD = 'MATCH'
 

--- a/spec/neo4j-core/unit/query_spec.rb
+++ b/spec/neo4j-core/unit/query_spec.rb
@@ -278,6 +278,14 @@ describe Neo4j::Core::Query do
     end
   end
 
+  # CALL
+
+  describe '#call' do
+    describe ".call('db.constraints()')" do
+      it_generates 'CALL db.constraints()'
+    end
+  end
+
   # USING
 
   describe '#using' do


### PR DESCRIPTION
This pull introduces/changes:
 * Adds support for `CALL` clause introduced in neo4j

Examples:

```ruby
Neo4j::Session.current.call("db.labels()") # => Generates "CALL db.labels()"
```

It's extremely useful to use the new procedure api of neo4j spatial.

Pings:
@cheerfulstoic
@subvertallchris

