### PR TITLE
Fixing BOLT adaptor bugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group 'development' do
   gem 'guard-rspec', require: false if RUBY_PLATFORM != 'java'
   if RUBY_VERSION.to_f < 2.0
     gem 'overcommit', '< 0.35.0'
+    gem 'term-ansicolor', '< 1.4'
   else
     gem 'overcommit'
   end

--- a/lib/neo4j/core/cypher_session/adaptors.rb
+++ b/lib/neo4j/core/cypher_session/adaptors.rb
@@ -57,7 +57,7 @@ ERROR
                                 ['neo4j', ::Neo4j::VERSION]
                               else
                                 ['neo4j-core', ::Neo4j::Core::VERSION]
-                         end
+                              end
 
 
           USER_AGENT_STRING = "#{gem_name}-gem/#{version} (https://github.com/neo4jrb/#{gem_name})"

--- a/lib/neo4j/core/cypher_session/adaptors.rb
+++ b/lib/neo4j/core/cypher_session/adaptors.rb
@@ -53,14 +53,14 @@ ERROR
         class Base
           include Neo4j::Core::Instrumentable
 
-          gem, version = if defined?(::Neo4j::ActiveNode)
-                           ['neo4j', ::Neo4j::VERSION]
-                         else
-                           ['neo4j-core', ::Neo4j::Core::VERSION]
+          gem_name, version = if defined?(::Neo4j::ActiveNode)
+                                ['neo4j', ::Neo4j::VERSION]
+                              else
+                                ['neo4j-core', ::Neo4j::Core::VERSION]
                          end
 
 
-          USER_AGENT_STRING = "#{gem}-gem/#{version} (https://github.com/neo4jrb/#{gem})"
+          USER_AGENT_STRING = "#{gem_name}-gem/#{version} (https://github.com/neo4jrb/#{gem_name})"
 
           def connect(*_args)
             fail '#connect not implemented!'
@@ -141,11 +141,11 @@ ERROR
 
               yield tx
             rescue => e
-              tx.mark_failed
+              tx.mark_failed if tx
 
               raise e
             ensure
-              tx.close
+              tx.close if tx
             end
           end
 

--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -44,7 +44,8 @@ module Neo4j
 
             if @socket.ready?
               debug_remaining_buffer
-              fail 'Making query, but expected there to be no buffer remaining!'
+              fail "Making query, but expected there to be no buffer remaining!\n"\
+                   "Queries: #{queries.map(&:cypher)}"
             end
 
             send_query_jobs(queries)

--- a/lib/neo4j/core/cypher_session/responses/bolt.rb
+++ b/lib/neo4j/core/cypher_session/responses/bolt.rb
@@ -52,10 +52,16 @@ module Neo4j
 
           def extract_message_groups(flush_messages_proc)
             fields_messages = flush_messages_proc.call
+
             validate_message_type!(fields_messages[0], :success)
 
             result_messages = []
-            while (messages = flush_messages_proc.call)[0].type != :success
+            messages = nil
+
+            loop do
+              messages = flush_messages_proc.call
+              next if messages.nil?
+              break if messages[0].type == :success
               result_messages.concat(messages)
             end
 
@@ -88,7 +94,7 @@ module Neo4j
             when :proc
               yield.wrap
             else
-              fail ArgumentError, "Inalid wrap_level: #{@wrap_level.inspect}"
+              fail ArgumentError, "Invalid wrap_level: #{@wrap_level.inspect}"
             end
           end
 

--- a/spec/neo4j/core/shared_examples/adaptor.rb
+++ b/spec/neo4j/core/shared_examples/adaptor.rb
@@ -15,6 +15,10 @@ RSpec.shared_examples 'Neo4j::Core::CypherSession::Adaptor' do
     it 'Can make a query' do
       adaptor.query(session_double, 'MERGE path=(n)-[rel:r]->(o) RETURN n, rel, o, path LIMIT 1')
     end
+
+    it 'can make a query with a large payload' do
+      adaptor.query(session_double, 'CREATE (n:Test) SET n = {props} RETURN n', props: {text: 'a' * 10_000})
+    end
   end
 
   describe '#queries' do


### PR DESCRIPTION
Fixes #269

This pull introduces/changes:
 * Improves error handling and debug messages for BOLT
 * Avoids this exception:
```
     # NoMethodError:
     #   undefined method `[]' for nil:NilClass
     #   ./lib/neo4j/core/cypher_session/responses/bolt.rb:68:in `block in extract_message_groups'
```

That was indirectly causing #269



Pings:
@cheerfulstoic
@subvertallchris