### PR TITLE
Implementing a after_commit callbacks

### DIFF
--- a/lib/neo4j/core/cypher_session/transactions.rb
+++ b/lib/neo4j/core/cypher_session/transactions.rb
@@ -19,6 +19,19 @@ module Neo4j
             adaptor.queries(@session, {transaction: self}.merge(options), &block)
           end
 
+          def after_commit_registry
+            @after_commit_registry ||= []
+          end
+
+          def after_commit(&block)
+            after_commit_registry << block
+          end
+
+          def post_close!
+            super
+            after_commit_registry.each(&:call) unless failed?
+          end
+
           private
 
           # Because we're inheriting from the old Transaction class


### PR DESCRIPTION
This pull introduces/changes:
 * A callback for getting notified of a transaction commit. Used to implement `after_commit` in neo4j. 



Pings:
@cheerfulstoic
@subvertallchris

