### PR TITLE
Check emptiness of index schema response body to protect from empty string

### DIFF
--- a/lib/neo4j/core/cypher_session/adaptors/http.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/http.rb
@@ -44,7 +44,7 @@ module Neo4j
           def indexes(_session)
             response = @requestor.get('db/data/schema/index')
 
-            list = response.body || []
+            list = response.body && !response.body.empty? ? response.body : []
 
             list.map do |item|
               {label: item[:label].to_sym,


### PR DESCRIPTION

Fixes

I experienced an issue while running a neo4j migration on GrapheneDB. My index schema response.body was returning an empty string rather than a nil body or empty array.

Stack Trace: 

```
NoMethodError: undefined method `map' for "":String
Did you mean?  tap
/app/vendor/bundle/ruby/2.3.0/gems/neo4j-core-7.0.3/lib/neo4j/core/cypher_session/adaptors/http.rb:48:in `indexes'
/app/vendor/bundle/ruby/2.3.0/gems/neo4j-core-7.0.3/lib/neo4j/core/cypher_session.rb:36:in `block (2 levels) in <class:CypherSession>'
/app/vendor/bundle/ruby/2.3.0/gems/neo4j-core-7.0.3/lib/neo4j/core/label.rb:64:in `indexes'
/app/vendor/bundle/ruby/2.3.0/gems/neo4j-core-7.0.3/lib/neo4j/core/label.rb:96:in `index?'
/app/vendor/bundle/ruby/2.3.0/gems/neo4j-8.0.5/lib/neo4j/migrations/helpers/schema.rb:20:in `add_index'
```

This pull introduces/changes:

This fix protects that case by checking for the response.body and then checking it's emptiness (.empty? works on both Strings and Arrays).




Pings:
@cheerfulstoic
@subvertallchris
