### PR TITLE
Handling messages sent in multiple chunks

### DIFF
--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -227,7 +227,7 @@ module Neo4j
 
           def flush_chunks(first_chunk_size)
             chunk_size = first_chunk_size
-            chunk = ""
+            chunk = ''
 
             loop do
               chunk += recvmsg(chunk_size)

--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -183,9 +183,9 @@ module Neo4j
             @socket.sendmsg(message)
           end
 
-          def recvmsg(size, peek = false, timeout = 10)
+          def recvmsg(size, timeout = 10)
             Timeout.timeout(timeout) do
-              @socket.recv(size, (Socket::MSG_PEEK if peek)).tap do |result|
+              @socket.recv(size).tap do |result|
                 log_message :S, result
               end
             end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -227,10 +227,10 @@ module Neo4j
 
           def flush_chunks(first_chunk_size)
             chunk_size = first_chunk_size
-            chunk = ''
+            chunk = String.new
 
             loop do
-              chunk += recvmsg(chunk_size)
+              chunk << recvmsg(chunk_size)
               chunk_size = recvmsg(2, true).unpack('s>*')[0]
 
               break if chunk_size.zero?

--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -183,9 +183,9 @@ module Neo4j
             @socket.sendmsg(message)
           end
 
-          def recvmsg(size, timeout = 10)
+          def recvmsg(size, peek = false, timeout = 10)
             Timeout.timeout(timeout) do
-              @socket.recv(size).tap do |result|
+              @socket.recv(size, (Socket::MSG_PEEK if peek)).tap do |result|
                 log_message :S, result
               end
             end
@@ -217,12 +217,27 @@ module Neo4j
             if !(header = recvmsg(2)).empty? && (chunk_size = header.unpack('s>*')[0]) > 0
               log_message :S, :chunk_size, chunk_size
 
-              chunk = recvmsg(chunk_size)
+              chunk = flush_chunks(chunk_size)
 
               unpacker = PackStream::Unpacker.new(StringIO.new(chunk))
 
               [].tap { |r| while arg = unpacker.unpack_value!; r << arg; end }
             end
+          end
+
+          def flush_chunks(first_chunk_size)
+            chunk_size = first_chunk_size
+            chunk = ""
+
+            loop do
+              chunk += recvmsg(chunk_size)
+              chunk_size = recvmsg(2, true).unpack('s>*')[0]
+
+              break if chunk_size.zero?
+              recvmsg(2)
+            end
+
+            chunk
           end
 
           # Represents messages sent to or received from the server

--- a/spec/neo4j/core/cypher_session/adaptors/bolt_spec.rb
+++ b/spec/neo4j/core/cypher_session/adaptors/bolt_spec.rb
@@ -44,13 +44,7 @@ describe Neo4j::Core::CypherSession::Adaptors::Bolt, bolt: true do
         "\x00\x00"
       ]
 
-      allow(adaptor).to receive(:recvmsg) do |_, peek|
-        if peek
-          responses.first
-        else
-          responses.shift
-        end
-      end
+      allow(adaptor).to receive(:recvmsg) { |_, peek| responses.public_send(peek ? :first : :shift) }
     end
 
     it 'handles chunked responses' do

--- a/spec/neo4j/core/cypher_session/adaptors/bolt_spec.rb
+++ b/spec/neo4j/core/cypher_session/adaptors/bolt_spec.rb
@@ -44,7 +44,7 @@ describe Neo4j::Core::CypherSession::Adaptors::Bolt, bolt: true do
         "\x00\x00"
       ]
 
-      allow(adaptor).to receive(:recvmsg) { |_, peek| responses.public_send(peek ? :first : :shift) }
+      allow(adaptor).to receive(:recvmsg) { responses.shift }
     end
 
     it 'handles chunked responses' do

--- a/spec/neo4j/core/cypher_session/adaptors/bolt_spec.rb
+++ b/spec/neo4j/core/cypher_session/adaptors/bolt_spec.rb
@@ -32,6 +32,33 @@ describe Neo4j::Core::CypherSession::Adaptors::Bolt, bolt: true do
     let_context(url: 'bolt://foo:bar@localhost:7687') { subject_should_not_raise }
   end
 
+  describe 'message in multiple chunks' do
+    before do
+      # This is standard response for INIT message, split into two chunks.
+      # Normally it has form of ["\x00\x03", "\xB1p\xA0", "\x00\x00"]
+      responses = [
+        "\x00\x02",
+        "\xB1p",
+        "\x00\x01",
+        "\xA0",
+        "\x00\x00"
+      ]
+
+      allow(adaptor).to receive(:recvmsg) do |_, peek|
+        if peek
+          responses.first
+        else
+          responses.shift
+        end
+      end
+    end
+
+    it 'handles chunked responses' do
+      adaptor.send(:init)
+      expect(adaptor.send(:flush_messages)[0].args.first).to eq({})
+    end
+  end
+
   context 'connected adaptor' do
     before { adaptor.connect }
 


### PR DESCRIPTION
This pull implements handling messages split into multiple chunks as described in BOLT spec http://boltprotocol.org/v1/#message_transfer_encoding

Currently if message is split into chunks `neo4j-core` ignores later parts, which results in incomplete labels or missing attributes (ex. in form of `{nil => nil}`).

Pings:
@cheerfulstoic
@subvertallchris
