### PR TITLE
Bump version of Faraday

### DIFF
--- a/neo4j-core.gemspec
+++ b/neo4j-core.gemspec
@@ -24,7 +24,7 @@ Neo4j-core provides classes and methods to work with the graph database Neo4j.
   s.extra_rdoc_files = %w( README.md )
   s.rdoc_options = ['--quiet', '--title', 'Neo4j::Core', '--line-numbers', '--main', 'README.rdoc', '--inline-source']
 
-  s.add_dependency('faraday', '~> 0.9.0')
+  s.add_dependency('faraday', '~> 0.11.0')
   s.add_dependency('net-http-persistent', '~> 2.9.4')
   s.add_dependency('httpclient')
   s.add_dependency('faraday_middleware', '~> 0.10.0')


### PR DESCRIPTION
This pull introduces/changes:
 * Version 0.9 of Faraday is a few years old which is now causing dependency
issues with other gems.

Pings:
@cheerfulstoic
@subvertallchris