### PR TITLE
Allow Faraday init params to be passed to HTTP adaptor

### DIFF
--- a/lib/neo4j/core/cypher_session/adaptors/http.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/http.rb
@@ -147,9 +147,9 @@ module Neo4j
               require 'faraday'
               require 'faraday_middleware/multi_json'
 
-              Faraday.new(url,params) do |c|
+              Faraday.new(url,options) do |c|
                 c.request :basic_auth, user, password
-                c.request :basic_auth, params[:basic_auth][:username], params[:basic_auth][:password] if params[:basic_auth]
+                c.request :basic_auth, options[:basic_auth][:username], options[:basic_auth][:password] if options[:basic_auth]
                 c.request :multi_json
 
                 c.response :multi_json, symbolize_keys: true, content_type: 'application/json'

--- a/lib/neo4j/core/cypher_session/adaptors/http.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/http.rb
@@ -147,9 +147,12 @@ module Neo4j
               require 'faraday'
               require 'faraday_middleware/multi_json'
 
-              Faraday.new(url,options) do |c|
-                c.request :basic_auth, user, password
-                c.request :basic_auth, options[:basic_auth][:username], options[:basic_auth][:password] if options[:basic_auth]
+            def faraday_connection(options = {})
+              require 'faraday'
+              require 'faraday_middleware/multi_json'
+
+              Faraday.new(url, options) do |c|
+                c.request :basic_auth, config_username(user, options), config_password(password, options)
                 c.request :multi_json
 
                 c.response :multi_json, symbolize_keys: true, content_type: 'application/json'
@@ -160,6 +163,14 @@ module Neo4j
                 c.headers['Content-Type'] = 'application/json'
                 c.headers['User-Agent'] = @user_agent_string
               end
+            end
+
+            def config_password(password, options)
+              options[:basic_auth] ? options[:basic_auth][:password] : password
+            end
+
+            def config_username(user, options)
+              options[:basic_auth] ? options[:basic_auth][:username] : user
             end
 
             def request_body(body)

--- a/lib/neo4j/core/cypher_session/adaptors/http.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/http.rb
@@ -147,10 +147,6 @@ module Neo4j
               require 'faraday'
               require 'faraday_middleware/multi_json'
 
-            def faraday_connection(options = {})
-              require 'faraday'
-              require 'faraday_middleware/multi_json'
-
               Faraday.new(url, options) do |c|
                 c.request :basic_auth, config_username(user, options), config_password(password, options)
                 c.request :multi_json

--- a/lib/neo4j/core/cypher_session/adaptors/http.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/http.rb
@@ -16,7 +16,7 @@ module Neo4j
           end
 
           def connect
-            @requestor = Requestor.new(@url, USER_AGENT_STRING, self.class.method(:instrument_request), @options[:faraday_opts] = {})
+            @requestor = Requestor.new(@url, USER_AGENT_STRING, self.class.method(:instrument_request), @options[:faraday_options] ||= {})
           end
 
           ROW_REST = %w(row REST)
@@ -101,13 +101,12 @@ module Neo4j
             include Adaptors::HasUri
             default_url('http://neo4:neo4j@localhost:7474')
             validate_uri { |uri| uri.is_a?(URI::HTTP) }
-            def initialize(url, user_agent_string, instrument_proc, params = {})
+            def initialize(url, user_agent_string, instrument_proc, faraday_options = {})
               self.url = url
               @user = user
               @password = password
               @user_agent_string = user_agent_string
-              init_params = params[:initialize] && params.delete(:initialize) if params.key?(:initialize)
-              @faraday = wrap_connection_failed! { faraday_connection(init_params) }
+              @faraday = wrap_connection_failed! { faraday_connection(faraday_options.fetch(:initialize, {})) }
               @instrument_proc = instrument_proc
             end
 
@@ -144,7 +143,7 @@ module Neo4j
 
             private
 
-            def faraday_connection(params = {})
+            def faraday_connection(options = {})
               require 'faraday'
               require 'faraday_middleware/multi_json'
 


### PR DESCRIPTION
This pull introduces/changes:
 * Restores the ability to pass Faraday request init params to allow things like over-riding the initial connection and request timeout values 
A new key called `:faraday_opts` is available for use in the options array passed to the HTTP adaptor

Example usage:
adaptor ||= Neo4j::Core::CypherSession::Adaptors::HTTP.new("http://"\
                                                                                                        "#{@user}:"\
                                                                     "#{@password}@"\
                                                                     "#{@host}:"\
                                                                     "#{@http_port}",
                                                                     faraday_opts: {initialize: { request: { open_timeout: 2, timeout: 600 }} })




Pings:
@cheerfulstoic
@subvertallchris
