### PR TITLE
fix ruby 2.4 Fixnum deprecations

### DIFF
--- a/lib/neo4j-embedded/property.rb
+++ b/lib/neo4j-embedded/property.rb
@@ -20,7 +20,7 @@ module Neo4j
 
       # Sets the property of this node.
       # Property keys are always strings. Valid property value types are the primitives:
-      # (<tt>String</tt>, <tt>Fixnum</tt>, <tt>Float</tt>, <tt>FalseClass</tt>, <tt>TrueClass</tt>)
+      # (<tt>String</tt>, <tt>Integer</tt>, <tt>Float</tt>, <tt>FalseClass</tt>, <tt>TrueClass</tt>)
       # or an array of those primitives.
       #
       # ==== Gotchas
@@ -28,7 +28,7 @@ module Neo4j
       # * You can *not* delete or add one item in the array (e.g. person.phones.delete('123')) but instead you must create a new array instead.
       #
       # @param [String, Symbol] k of the property to set
-      # @param [String,Fixnum,Float,true,false, Array] v to set
+      # @param [String,Integer,Float,true,false, Array] v to set
       def []=(k, v)
         to_java_property(k, v)
       end
@@ -95,7 +95,7 @@ module Neo4j
           :double
         when FalseClass, TrueClass
           :boolean
-        when Fixnum
+        when Integer
           :long
         else
           fail "Not allowed to store array with value #{value.inspect} type #{value.class}"

--- a/lib/neo4j/property_validator.rb
+++ b/lib/neo4j/property_validator.rb
@@ -5,12 +5,12 @@ module Neo4j
     end
 
     # the valid values on a property, and arrays of those.
-    VALID_PROPERTY_VALUE_CLASSES = Set.new([Array, NilClass, String, Float, TrueClass, FalseClass, Fixnum])
+    VALID_PROPERTY_VALUE_CLASSES = Set.new([Array, NilClass, String, Float, TrueClass, FalseClass, Integer])
 
     # @param [Object] value the value we want to check if it's a valid neo4j property value
     # @return [True, False] A false means it can't be persisted.
     def valid_property?(value)
-      VALID_PROPERTY_VALUE_CLASSES.include?(value.class)
+      VALID_PROPERTY_VALUE_CLASSES.any? { |c| value.is_a?(c) }
     end
 
     def validate_property!(value)

--- a/spec/shared_examples/node_auto_tx.rb
+++ b/spec/shared_examples/node_auto_tx.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples 'Neo4j::Node auto tx' do
         subject { Neo4j::Node.create }
 
         its(:exist?) { should be true }
-        its(:neo_id) { should be_a(Fixnum) }
+        its(:neo_id) { should be_a(Integer) }
         its(:props) { should == {} }
       end
 
@@ -19,7 +19,7 @@ RSpec.shared_examples 'Neo4j::Node auto tx' do
         subject { Neo4j::Node.create(name: 'kalle', age: 42) }
 
         its(:exist?) { should be true }
-        its(:neo_id) { should be_a(Fixnum) }
+        its(:neo_id) { should be_a(Integer) }
         its(:props) { should == {name: 'kalle', age: 42} }
 
         it 'read the properties using []' do
@@ -73,7 +73,7 @@ RSpec.shared_examples 'Neo4j::Node auto tx' do
       describe 'neo_id' do
         it 'returns the neo4j id' do
           neo_id = node.neo_id
-          expect(neo_id).to be_a(Fixnum)
+          expect(neo_id).to be_a(Integer)
         end
       end
 
@@ -138,7 +138,7 @@ RSpec.shared_examples 'Neo4j::Node auto tx' do
           expect(node[:foo]).to eq('bar')
         end
 
-        it 'can write and read Fixnum' do
+        it 'can write and read Integer' do
           node[:foo] = 42
           expect(node[:foo]).to eq(42)
         end
@@ -156,7 +156,7 @@ RSpec.shared_examples 'Neo4j::Node auto tx' do
         end
 
         context 'reading/writing Arrays' do
-          it 'can handle ruby arrays of Fixnum' do
+          it 'can handle ruby arrays of Integer' do
             node[:foo] = [1, 2, 3]
             expect(node[:foo]).to eq [1, 2, 3]
             expect(node[:foo]).to be_an(Array)
@@ -323,7 +323,7 @@ RSpec.shared_examples 'Neo4j::Node auto tx' do
       describe 'create_rel' do
         it 'can create a new relationship' do
           rel = node_a.create_rel(:best_friend, node_b)
-          expect(rel.neo_id).to be_a_kind_of(Fixnum)
+          expect(rel.neo_id).to be_a_kind_of(Integer)
           expect(rel.exist?).to be true
         end
 

--- a/spec/shared_examples/node_auto_tx.rb
+++ b/spec/shared_examples/node_auto_tx.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples 'Neo4j::Node auto tx' do
         subject { Neo4j::Node.create }
 
         its(:exist?) { should be true }
-        its(:neo_id) { should be_a(Integer) }
+        its(:neo_id) { should be_an(Integer) }
         its(:props) { should == {} }
       end
 
@@ -19,7 +19,7 @@ RSpec.shared_examples 'Neo4j::Node auto tx' do
         subject { Neo4j::Node.create(name: 'kalle', age: 42) }
 
         its(:exist?) { should be true }
-        its(:neo_id) { should be_a(Integer) }
+        its(:neo_id) { should be_an(Integer) }
         its(:props) { should == {name: 'kalle', age: 42} }
 
         it 'read the properties using []' do
@@ -73,7 +73,7 @@ RSpec.shared_examples 'Neo4j::Node auto tx' do
       describe 'neo_id' do
         it 'returns the neo4j id' do
           neo_id = node.neo_id
-          expect(neo_id).to be_a(Integer)
+          expect(neo_id).to be_an(Integer)
         end
       end
 

--- a/spec/shared_examples/node_with_tx.rb
+++ b/spec/shared_examples/node_with_tx.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples 'Neo4j::Node with tx' do
   shared_examples 'a node with properties and id' do
     describe '#neo_id' do
       it 'is a fixnum' do
-        expect(subject.neo_id).to be_a(Fixnum)
+        expect(subject.neo_id).to be_a(Integer)
       end
     end
 

--- a/spec/shared_examples/node_with_tx.rb
+++ b/spec/shared_examples/node_with_tx.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples 'Neo4j::Node with tx' do
   shared_examples 'a node with properties and id' do
     describe '#neo_id' do
       it 'is a fixnum' do
-        expect(subject.neo_id).to be_a(Integer)
+        expect(subject.neo_id).to be_an(Integer)
       end
     end
 

--- a/spec/shared_examples/session.rb
+++ b/spec/shared_examples/session.rb
@@ -33,7 +33,7 @@ RSpec.shared_examples 'Neo4j::Session' do
         expect(node[:version]).to eq(1.1)
       end
 
-      it 'allows finding nodes by a key with a Fixnum value' do
+      it 'allows finding nodes by a key with an Integer value' do
         node = session.find_nodes(:label, :id, 2).first
         verify node
       end


### PR DESCRIPTION
Fixes #289 

This pull introduces/changes:
 * Substitutes Integer for Fixnum
 * Retains Ruby <=2.3 compatibility

Pings:
@cheerfulstoic
@subvertallchris
