### PR TITLE
Add support for querying non-integer ranges

### DIFF
--- a/lib/neo4j-core/query_clauses.rb
+++ b/lib/neo4j-core/query_clauses.rb
@@ -196,7 +196,7 @@ module Neo4j
           self.class.paramaterize_key!(param)
 
           if value.is_a?(Range)
-            range_key_value_string(key, value, previous_keys)
+            range_key_value_string(key, value, previous_keys, param)
           else
             value = value.first if array_value?(value, is_set) && value.size == 1
             operator = array_value?(value, is_set) ? 'IN' : '='
@@ -207,7 +207,7 @@ module Neo4j
           end
         end
 
-        def range_key_value_string(key, value, previous_keys)
+        def range_key_value_string(key, value, previous_keys, param)
           case value.begin
           when Integer
             min_param, max_param = add_params("#{param}_range_min" => value.min, "#{param}_range_max" => value.max)

--- a/lib/neo4j-core/query_clauses.rb
+++ b/lib/neo4j-core/query_clauses.rb
@@ -196,14 +196,7 @@ module Neo4j
           self.class.paramaterize_key!(param)
 
           if value.is_a?(Range)
-            case value.begin
-            when Integer
-              min_param, max_param = add_params("#{param}_range_min" => value.min, "#{param}_range_max" => value.max)
-              "#{key} IN RANGE({#{min_param}}, {#{max_param}})"
-            else
-              min_param, max_param = add_params("#{param}_range_min" => value.begin, "#{param}_range_max" => value.end)
-              "#{key} >= {#{min_param}} AND #{previous_keys[-2]}.#{key} <#{'=' unless value.exclude_end?} {#{max_param}}"
-            end
+            range_key_value_string(key, value, previous_keys)
           else
             value = value.first if array_value?(value, is_set) && value.size == 1
             operator = array_value?(value, is_set) ? 'IN' : '='
@@ -211,6 +204,17 @@ module Neo4j
             param = add_param(param, value)
 
             "#{key} #{operator} {#{param}}"
+          end
+        end
+
+        def range_key_value_string(key, value, previous_keys)
+          case value.begin
+          when Integer
+            min_param, max_param = add_params("#{param}_range_min" => value.min, "#{param}_range_max" => value.max)
+            "#{key} IN RANGE({#{min_param}}, {#{max_param}})"
+          else
+            min_param, max_param = add_params("#{param}_range_min" => value.begin, "#{param}_range_max" => value.end)
+            "#{key} >= {#{min_param}} AND #{previous_keys[-2]}.#{key} <#{'=' unless value.exclude_end?} {#{max_param}}"
           end
         end
 

--- a/spec/neo4j-core/unit/query_spec.rb
+++ b/spec/neo4j-core/unit/query_spec.rb
@@ -396,6 +396,25 @@ describe Neo4j::Core::Query do
     describe '.where(q: {age: (30..40)})' do
       it_generates 'WHERE (q.age IN RANGE({q_age_range_min}, {q_age_range_max}))', q_age_range_min: 30, q_age_range_max: 40
     end
+
+    # Non-integer ranges
+    describe '.where(q: { created_at: 0.0...5.0 })' do
+      it_generates 'WHERE (q.created_at >= {q_created_at_range_min} AND q.created_at < {q_created_at_range_max})',
+        q_created_at_range_min: 0.0,
+        q_created_at_range_max: 5.0
+    end
+
+    describe '.where(q: { created_at: Date.new(2017, 6, 1)...Date.new(2017, 6, 3) })' do
+      it_generates 'WHERE (q.created_at >= {q_created_at_range_min} AND q.created_at < {q_created_at_range_max})',
+        q_created_at_range_min: Date.new(2017, 6, 1),
+        q_created_at_range_max: Date.new(2017, 6, 3)
+    end
+
+    describe '.where(q: { created_at: Date.new(2017, 6, 1)..Date.new(2017, 6, 3) })' do
+      it_generates 'WHERE (q.created_at >= {q_created_at_range_min} AND q.created_at <= {q_created_at_range_max})',
+        q_created_at_range_min: Date.new(2017, 6, 1),
+        q_created_at_range_max: Date.new(2017, 6, 3)
+    end
   end
 
   describe '#where_not' do


### PR DESCRIPTION
Passing a time or date range wasn't working when serialized as non-integer values (I've been using strings for query readability) for two reasons:

- Neo4j expected numeric values for the `RANGE` function
- Ruby's `Range#max` doesn't work for non-integer values when the range excludes the high end

This commit expands support for ranges to include non-numeric ranges and non-integer exclusive ranges through the use of `Range#end` rather than `Range#max`. It leaves integer-range support alone in case Neo4j has internal optimizations for it. I also included a spec for the float-range exclusive case and confirmed it raised a `TypeError` before making any changes to the `lib` code.

Pings:
@cheerfulstoic (seems to have the most commits on this file)