### PR TITLE
Fix specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,42 +15,42 @@ sudo: false
 jdk: oraclejdk8
 rvm:
   - 2.3.1
-#  - 2.2.5
-#  - jruby-9.1.12.0
+  - 2.2.5
+  - jruby-9.1.12.0
 env:
   global:
     - JRUBY_OPTS="-J-Xmx1024m -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
     - NEO4J_URL="http://localhost:7474"
     - NEO4J_BOLT_URL="bolt://localhost:7472"
-#  matrix:
-#    - NEO4J_VERSION=community-3.2.1
+  matrix:
+    - NEO4J_VERSION=community-3.2.1
 matrix:
   include:
-#    - script: "bundle exec rubocop"
-#      rvm: 2.3.1
-#      jdk:
-#      before_script:
-#      env: "RUBOCOP=true"
+    - script: "bundle exec rubocop"
+      rvm: 2.3.1
+      jdk:
+      before_script:
+      env: "RUBOCOP=true"
 
     # Older versions of Neo4j with latest version of Ruby
-#    - rvm: 2.3.1
-#      env: NEO4J_VERSION=community-3.1.5
-#    - rvm: 2.3.1
-#      env: NEO4J_VERSION=community-2.3.11
-#    - rvm: 2.3.1
-#      env: NEO4J_VERSION=community-2.1.8
+    - rvm: 2.3.1
+      env: NEO4J_VERSION=community-3.1.5
+    - rvm: 2.3.1
+      env: NEO4J_VERSION=community-2.3.11
+    - rvm: 2.3.1
+      env: NEO4J_VERSION=community-2.1.8
 
     # Older versions of Neo4j with latest version of jRuby
-#    - rvm: jruby-9.1.12.0
-#      env: NEO4J_VERSION=community-3.1.5
-#    - rvm: jruby-9.1.12.0
-#      env: NEO4J_VERSION=community-2.3.11
-#    - rvm: jruby-9.1.12.0
-#      env: NEO4J_VERSION=community-2.1.8
+    - rvm: jruby-9.1.12.0
+      env: NEO4J_VERSION=community-3.1.5
+    - rvm: jruby-9.1.12.0
+      env: NEO4J_VERSION=community-2.3.11
+    - rvm: jruby-9.1.12.0
+      env: NEO4J_VERSION=community-2.1.8
 
     # NEW_NEO4J_SESSIONS
-#    - rvm: jruby-9.1.12.0
-#      env: RSPEC_OPTS="--tag new_cypher_session" NEO4J_VERSION=community-2.3.11 NEW_NEO4J_SESSIONS=true
+    - rvm: jruby-9.1.12.0
+      env: RSPEC_OPTS="--tag new_cypher_session" NEO4J_VERSION=community-2.3.11 NEW_NEO4J_SESSIONS=true
 
     # Enterprise
     - rvm: 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ before_script:
   - "bin/rake neo4j:install[$NEO4J_VERSION] --trace"
   - "bin/rake neo4j:config[development,7474] --trace"
   - "if [ -f ./db/neo4j/development/conf/neo4j-wrapper.conf ]; then WRAPPER=-wrapper; fi"
-  - "echo 'dbms.memory.pagecache.size=1g' >> ./db/neo4j/development/conf/neo4j.conf"
-  - "echo 'dbms.memory.heap.max_size=1000' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
-  - "echo 'dbms.memory.heap.initial_size=1000' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
+  - "echo 'dbms.memory.pagecache.size=600m' >> ./db/neo4j/development/conf/neo4j.conf"
+  - "echo 'dbms.memory.heap.max_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
+  - "echo 'dbms.memory.heap.initial_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "bin/rake neo4j:start --trace"
   - "sleep 20"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_script:
   - "echo 'dbms.memory.heap.max_size=1000' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "echo 'dbms.memory.heap.initial_size=1000' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "bin/rake neo4j:start --trace"
-  - travis_debug
   - "sleep 20"
 script:
   - "bundle exec rspec $RSPEC_OPTS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
   - "echo 'dbms.memory.heap.max_size=1000' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "echo 'dbms.memory.heap.initial_size=1000' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "bin/rake neo4j:start --trace"
+  - travis_debug
   - "sleep 20"
 script:
   - "bundle exec rspec $RSPEC_OPTS"
@@ -15,42 +16,42 @@ sudo: false
 jdk: oraclejdk8
 rvm:
   - 2.3.1
-  - 2.2.5
-  - jruby-9.1.12.0
+#  - 2.2.5
+#  - jruby-9.1.12.0
 env:
   global:
     - JRUBY_OPTS="-J-Xmx1024m -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
     - NEO4J_URL="http://localhost:7474"
     - NEO4J_BOLT_URL="bolt://localhost:7472"
-  matrix:
-    - NEO4J_VERSION=community-3.2.1
+#  matrix:
+#    - NEO4J_VERSION=community-3.2.1
 matrix:
   include:
-    - script: "bundle exec rubocop"
-      rvm: 2.3.1
-      jdk:
-      before_script:
-      env: "RUBOCOP=true"
+#    - script: "bundle exec rubocop"
+#      rvm: 2.3.1
+#      jdk:
+#      before_script:
+#      env: "RUBOCOP=true"
 
     # Older versions of Neo4j with latest version of Ruby
-    - rvm: 2.3.1
-      env: NEO4J_VERSION=community-3.1.5
-    - rvm: 2.3.1
-      env: NEO4J_VERSION=community-2.3.11
-    - rvm: 2.3.1
-      env: NEO4J_VERSION=community-2.1.8
+#    - rvm: 2.3.1
+#      env: NEO4J_VERSION=community-3.1.5
+#    - rvm: 2.3.1
+#      env: NEO4J_VERSION=community-2.3.11
+#    - rvm: 2.3.1
+#      env: NEO4J_VERSION=community-2.1.8
 
     # Older versions of Neo4j with latest version of jRuby
-    - rvm: jruby-9.1.12.0
-      env: NEO4J_VERSION=community-3.1.5
-    - rvm: jruby-9.1.12.0
-      env: NEO4J_VERSION=community-2.3.11
-    - rvm: jruby-9.1.12.0
-      env: NEO4J_VERSION=community-2.1.8
+#    - rvm: jruby-9.1.12.0
+#      env: NEO4J_VERSION=community-3.1.5
+#    - rvm: jruby-9.1.12.0
+#      env: NEO4J_VERSION=community-2.3.11
+#    - rvm: jruby-9.1.12.0
+#      env: NEO4J_VERSION=community-2.1.8
 
     # NEW_NEO4J_SESSIONS
-    - rvm: jruby-9.1.12.0
-      env: RSPEC_OPTS="--tag new_cypher_session" NEO4J_VERSION=community-2.3.11 NEW_NEO4J_SESSIONS=true
+#    - rvm: jruby-9.1.12.0
+#      env: RSPEC_OPTS="--tag new_cypher_session" NEO4J_VERSION=community-2.3.11 NEW_NEO4J_SESSIONS=true
 
     # Enterprise
     - rvm: 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 before_script:
   - "bin/rake neo4j:install[$NEO4J_VERSION] --trace"
   - "bin/rake neo4j:config[development,7474] --trace"
+  - "if [ -f ./db/neo4j/development/conf/neo4j-wrapper.conf ]; then WRAPPER=-wrapper; fi"
   - "echo 'dbms.memory.pagecache.size=1g' >> ./db/neo4j/development/conf/neo4j.conf"
-  - "echo 'dbms.memory.heap.max_size=1000' >> ./db/neo4j/development/conf/neo4j-wrapper.conf"
-  - "echo 'dbms.memory.heap.initial_size=1000' >> ./db/neo4j/development/conf/neo4j-wrapper.conf"
+  - "echo 'dbms.memory.heap.max_size=1000' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
+  - "echo 'dbms.memory.heap.initial_size=1000' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "bin/rake neo4j:start --trace"
-  - "sleep 10"
+  - "sleep 20"
 script:
   - "bundle exec rspec $RSPEC_OPTS"
 language: ruby
@@ -15,15 +16,14 @@ jdk: oraclejdk8
 rvm:
   - 2.3.1
   - 2.2.5
-  - jruby-9.0.4.0
+  - jruby-9.1.12.0
 env:
   global:
     - JRUBY_OPTS="-J-Xmx1024m -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
     - NEO4J_URL="http://localhost:7474"
     - NEO4J_BOLT_URL="bolt://localhost:7472"
   matrix:
-    - NEO4J_VERSION=community-3.1.2
-    - NEO4J_VERSION=community-3.0.9
+    - NEO4J_VERSION=community-3.2.1
 matrix:
   include:
     - script: "bundle exec rubocop"
@@ -34,25 +34,24 @@ matrix:
 
     # Older versions of Neo4j with latest version of Ruby
     - rvm: 2.3.1
-      env: NEO4J_VERSION=community-3.0.9
+      env: NEO4J_VERSION=community-3.1.5
     - rvm: 2.3.1
-      env: NEO4J_VERSION=community-2.3.9
-    - rvm: 2.3.1
-      env: NEO4J_VERSION=community-2.2.10
+      env: NEO4J_VERSION=community-2.3.11
     - rvm: 2.3.1
       env: NEO4J_VERSION=community-2.1.8
 
     # Older versions of Neo4j with latest version of jRuby
-    - rvm: jruby-9.0.4.0
-      env: NEO4J_VERSION=community-3.0.9
-    - rvm: jruby-9.0.4.0
-      env: NEO4J_VERSION=community-2.3.9
-    - rvm: jruby-9.0.4.0
-      env: NEO4J_VERSION=community-2.2.10
-    - rvm: jruby-9.0.4.0
+    - rvm: jruby-9.1.12.0
+      env: NEO4J_VERSION=community-3.1.5
+    - rvm: jruby-9.1.12.0
+      env: NEO4J_VERSION=community-2.3.11
+    - rvm: jruby-9.1.12.0
       env: NEO4J_VERSION=community-2.1.8
 
     # NEW_NEO4J_SESSIONS
-    - rvm: jruby-9.0.4.0
-      env: RSPEC_OPTS="--tag new_cypher_session" NEO4J_VERSION=community-2.3.5 NEW_NEO4J_SESSIONS=true
+    - rvm: jruby-9.1.12.0
+      env: RSPEC_OPTS="--tag new_cypher_session" NEO4J_VERSION=community-2.3.11 NEW_NEO4J_SESSIONS=true
 
+    # Enterprise
+    - rvm: 2.3.1
+      env: NEO4J_VERSION=enterprise-3.2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,3 +55,8 @@ matrix:
     # Enterprise
     - rvm: 2.3.1
       env: NEO4J_VERSION=enterprise-3.2.1
+
+after_failure:
+  - cat ./db/neo4j/development/logs/neo4j.log
+  - cat ./db/neo4j/development/logs/debug.log
+  - cat ./db/neo4j/development/conf/neo4j.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - "echo 'dbms.memory.heap.max_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "echo 'dbms.memory.heap.initial_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "bin/rake neo4j:start --trace"
-  - "sleep 20"
+  - "sleep 120"
 script:
   - "bundle exec rspec $RSPEC_OPTS"
 language: ruby

--- a/spec/neo4j-core/unit/query_spec.rb
+++ b/spec/neo4j-core/unit/query_spec.rb
@@ -415,25 +415,6 @@ describe Neo4j::Core::Query do
                    q_created_at_range_min: Date.new(2017, 6, 1),
                    q_created_at_range_max: Date.new(2017, 6, 3)
     end
-
-    # Non-integer ranges
-    describe '.where(q: { created_at: 0.0...5.0 })' do
-      it_generates 'WHERE (q.created_at >= {q_created_at_range_min} AND q.created_at < {q_created_at_range_max})',
-        q_created_at_range_min: 0.0,
-        q_created_at_range_max: 5.0
-    end
-
-    describe '.where(q: { created_at: Date.new(2017, 6, 1)...Date.new(2017, 6, 3) })' do
-      it_generates 'WHERE (q.created_at >= {q_created_at_range_min} AND q.created_at < {q_created_at_range_max})',
-        q_created_at_range_min: Date.new(2017, 6, 1),
-        q_created_at_range_max: Date.new(2017, 6, 3)
-    end
-
-    describe '.where(q: { created_at: Date.new(2017, 6, 1)..Date.new(2017, 6, 3) })' do
-      it_generates 'WHERE (q.created_at >= {q_created_at_range_min} AND q.created_at <= {q_created_at_range_max})',
-        q_created_at_range_min: Date.new(2017, 6, 1),
-        q_created_at_range_max: Date.new(2017, 6, 3)
-    end
   end
 
   describe '#where_not' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,11 @@
 # To run coverage via travis
+require 'simplecov'
 require 'coveralls'
-Coveralls.wear!
-# require 'simplecov'
-# SimpleCov.start
+
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+  add_filter 'spec'
+end
 
 # To run it manually via Rake
 if ENV['COVERAGE']


### PR DESCRIPTION
Made travis configuration changes to make build pass.

Fixes #

This pull introduces/changes:
 *  Memory configuration changes
 *  Used extremely long sleep after neo4j:start as in some cases the startup process took over 1 minute, this has to be fixed with a better ready detection strategy in rake neo4j:start (another day in another PR)
 * Refreshed the tested ruby and neo4j versions
 * Removed identical spec block
 * exluded spec directory from coveralls, we should measure the code percentage the specs cover while the specs code itself should not be measured as in my case above removing an identical block of specs which were actually hit reduced the percentage of hit lines. Now the coverage is reported much lower but that is the correct number. Once this PR is accepted the future deltas will be adequate.

Pings:
@cheerfulstoic
@subvertallchris
