### PR TITLE
Make Bolt adaptor work with JRuby

### DIFF
--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -182,7 +182,7 @@ module Neo4j
           def sendmsg(message)
             log_message :C, message
 
-            @socket.sendmsg(message)
+            @socket.send(message, 0)
           end
 
           def recvmsg(size, timeout = 10)


### PR DESCRIPTION
JRuby does not support `BasicSocket#sendmsg` (connecting via Bolt on JRuby crashed with a `NotImplementedError`), but it does support `BasicSocket#send`. `send` requires flags to be specified, but [`sendmsg` defaults them to `0`](http://ruby-doc.org/stdlib-2.4.1/libdoc/socket/rdoc/BasicSocket.html#method-i-sendmsg), so I just used that since we weren't overriding that default here anyway.

This all started as an experiment to see if JRuby would run Bolt faster than HTTP, but that's not the case, unfortunately. JRuby Bolt is indeed over 2.5x as fast as CRuby Bolt, but still lags behind JRuby HTTP and CRuby HTTP (which are actually pretty close to each other) by about 37%.

Tested with JRuby 9.1.12.0 on Java 8 on queries deserializing 18k nodes.

Pings:
@cheerfulstoic
@subvertallchris