### PR TITLE
Check Neo4j server responsiveness for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - "echo 'dbms.memory.heap.max_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "echo 'dbms.memory.heap.initial_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "bin/rake neo4j:start --trace"
-  - "sleep 120"
+  - "while [ $((curl localhost:7474/ > /dev/null 2>&1); echo $?) -ne 0 ]; do; sleep 1; done"
 script:
   - "bundle exec rspec $RSPEC_OPTS"
 language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - "echo 'dbms.memory.heap.max_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "echo 'dbms.memory.heap.initial_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "bin/rake neo4j:start --trace"
-  - "while [ $((curl localhost:7474/ > /dev/null 2>&1); echo $?) -ne 0 ]; do; sleep 1; done"
+  - "while [ $((curl localhost:7474/ > /dev/null 2>&1); echo $?) -ne 0 ]; do sleep 1; done"
 script:
   - "bundle exec rspec $RSPEC_OPTS"
 language: ruby


### PR DESCRIPTION
This PR is intended to make CI builds faster without jumping the gun on the server by looping until the server responds. This will also guard against the possibility of the Neo4j server taking > 2 minutes to accept connections.

It is throttled to check only once per second so it doesn't waste CPU resources spinning up processes that it could be spending on spinning up the Neo4j server.



Pings:
@cheerfulstoic
@subvertallchris
