### PR TITLE
Support `https://` urls sans Bundler

### DIFF
--- a/lib/neo4j/core/cypher_session/adaptors/http.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/http.rb
@@ -1,6 +1,7 @@
 require 'neo4j/core/cypher_session/adaptors'
 require 'neo4j/core/cypher_session/adaptors/has_uri'
 require 'neo4j/core/cypher_session/responses/http'
+require 'uri'
 
 # TODO: Work with `Query` objects
 module Neo4j


### PR DESCRIPTION
Validation of an https URL fails without Bundler.  It's possible to run
migrations without during development and then get very confused when
you try to deploy to a production system.

Fixes #305 

This pull introduces/changes:
 * a missing `require` statement.




Pings:
@cheerfulstoic
@subvertallchris
