### PR TITLE
feature: .union() & .union_all() query clause methods

### DIFF
--- a/lib/neo4j-core/query.rb
+++ b/lib/neo4j-core/query.rb
@@ -175,7 +175,6 @@ module Neo4j
 
         DEFINED_CLAUSES[clause.to_sym] = clause_class
         define_method(clause) do |*args|
-          # the args splat will contain the method options, if any were given
           build_deeper_query(clause_class, args).ergo do |result|
             BREAK_METHODS.include?(clause) ? result.break : result
           end

--- a/lib/neo4j-core/query.rb
+++ b/lib/neo4j-core/query.rb
@@ -163,6 +163,7 @@ module Neo4j
       # DETACH DELETE clause
       # @return [Query]
 
+      # This ordering of the METHODS will be used when constructing the final cypher query
       METHODS = %w[start match optional_match call using where create create_unique merge set on_create_set on_match_set remove unwind delete detach_delete with return order skip limit union] # rubocop:disable Metrics/LineLength
       BREAK_METHODS = %(with call)
 

--- a/lib/neo4j-core/query_clauses.rb
+++ b/lib/neo4j-core/query_clauses.rb
@@ -732,6 +732,11 @@ module Neo4j
       class UnionClause < Clause
         KEYWORD = 'UNION'
 
+        def initialize(arg, params, options = {})
+          fail ArgError unless arg
+          super
+        end
+
         def from_query(value)
           from_string(value.to_cypher)
         end
@@ -739,7 +744,9 @@ module Neo4j
         class << self
           # Union clauses can only be called with a string or Query argument
           def from_args(args, params, options = {})
-            from_arg(arg, params, options)
+            arg = args.first
+
+            [from_arg(arg, params, options)]
           end
 
           def from_arg(arg, params, options = {})

--- a/lib/neo4j-core/query_clauses.rb
+++ b/lib/neo4j-core/query_clauses.rb
@@ -772,7 +772,6 @@ module Neo4j
             strings = clause_strings(clauses, pretty)
             stripped_string = strings.join(clause_join)
             stripped_string.strip!
-            (pretty && strings.size > 1) ? self::PRETTY_NEW_LINE + stripped_string : stripped_string
           end
 
           # If `.union()` was called with `all: true` option, insert 'UNION ALL' clause
@@ -794,7 +793,7 @@ module Neo4j
           end
 
           def clause_join(options = {})
-            ' '
+            ''
           end
         end
       end

--- a/lib/neo4j-core/query_clauses.rb
+++ b/lib/neo4j-core/query_clauses.rb
@@ -783,5 +783,3 @@ module Neo4j
     end
   end
 end
-
-union(query, {all: true})


### PR DESCRIPTION
Fixes #308 

Currently, both `.union()` and `.union_all()` are working for my (limited) testing.

I wanted to run my implementation by you before writing any tests / docs. You were correct, the query clause method implementation is rather confusing.

* `query.union_all(query)` adds a `UNION ALL` clause
* `query.union(query)` adds a `UNION` clause

You can pass either a query object or a string to union / union_all.

Some added benefits come if you use a query object for the union clause's argument:
* `.pluck()`ing the base query will overwrite the `return` of the union clause
* the cypher output in the console gets pretty formatting


Pings:
@cheerfulstoic
@subvertallchris
