### PR TITLE
Support TLS connections in BOLT adapter

### DIFF
--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -204,13 +204,23 @@ module Neo4j
           def sendmsg(message)
             log_message :C, message
 
-            @socket.send(message, 0)
+            if secure_connection?
+              @socket.write(message)
+            else
+              @socket.send(message, 0)
+            end
           end
 
           def recvmsg(size, timeout = timeout_option)
             Timeout.timeout(timeout) do
-              @socket.recv(size).tap do |result|
-                log_message :S, result
+              if secure_connection?
+                @socket.read(size).tap do |result|
+                  log_message :S, result
+                end
+              else
+                @socket.recv(size).tap do |result|
+                  log_message :S, result
+                end
               end
             end
           rescue Timeout::Error

--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -12,14 +12,14 @@ module Neo4j
   module Core
     class CypherSession
       module Adaptors
-        class Bolt < Base
+        class Bolt < Base # rubocop:disable Metrics/ClassLength
           include Adaptors::HasUri
           default_url('bolt://neo4:neo4j@localhost:7687')
           validate_uri do |uri|
             uri.scheme == 'bolt'
           end
 
-          SUPPORTED_VERSIONS = [1, 0, 0, 0].freeze # Do we need to modify the supported version when using SSL/TLS?
+          SUPPORTED_VERSIONS = [1, 0, 0, 0].freeze
           VERSION = '0.0.1'.freeze
 
           def initialize(url, options = {})
@@ -275,11 +275,7 @@ module Neo4j
           def ssl_params_from_options
             ssl_options = @options.fetch(:ssl)
             default_options = {verify_mode: OpenSSL::SSL::VERIFY_PEER}
-            if ssl_options.is_a? Hash
-              default_options.merge ssl_options
-            else
-              default_options
-            end
+            ssl_options.is_a?(Hash) ? default_options.merge!(ssl_options) : default_options
           end
 
           # Represents messages sent to or received from the server


### PR DESCRIPTION
This is an early attempt on adding TLS support for the BOLT adaptor. Right now I could use some help/feedback on the following topics:

 - Once this is finished, what changes should be made to `neo4jrb` to support this? Will be enough moving up the dependency version?
- Regarding the certificates, it's not clear to me if we need to add or not certificate files... According to @kfreytag from Neo4J slack: 
`The ruby client should natively support SSL / TLS without any mucking with certificates. The client deals with making sure they're valid, so you _should_ (emphasis added) be able to just specify that it's an SSL (or secure) connection and have it "just work"`

Given that, where should be check that server certificates are valid? Only in the bolt adaptor or somewhere else in the gem?


Pings:
@cheerfulstoic
@subvertallchris
