### PR TITLE
Refactoring, cleanup and generalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jdk: oraclejdk8
 rvm:
   - 2.4.2
   - 2.1.10
-  - jruby-9.1.14.0
+  - jruby-9.2.0.0
 env:
   global:
     - JRUBY_OPTS="-J-Xmx1024m -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
@@ -43,22 +43,22 @@ matrix:
       env: NEO4J_VERSION=community-2.1.8
 
     # Older versions of Neo4j with latest version of jRuby
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.2.0.0
       env: NEO4J_VERSION=community-3.2.8
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.2.0.0
       env: NEO4J_VERSION=community-3.1.7
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.2.0.0
       env: NEO4J_VERSION=community-2.3.11
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.2.0.0
       env: NEO4J_VERSION=community-2.1.8
 
     # NEW_NEO4J_SESSIONS
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.2.0.0
       env: RSPEC_OPTS="--tag new_cypher_session" NEO4J_VERSION=community-2.3.11 NEW_NEO4J_SESSIONS=true
 
     # Enterprise
     - rvm: 2.4.2
-      env: NEO4J_VERSION=enterprise-3.2.1
+      env: NEO4J_VERSION=enterprise-3.4.0
 
 after_failure:
   - cat ./db/neo4j/development/logs/neo4j.log

--- a/lib/neo4j/core/cypher_session.rb
+++ b/lib/neo4j/core/cypher_session.rb
@@ -1,7 +1,10 @@
+require 'active_support'
+
 module Neo4j
   module Core
     class CypherSession
       attr_reader :adaptor
+      delegate :close, to: :adaptor
 
       def initialize(adaptor)
         fail ArgumentError, "Invalid adaptor: #{adaptor.inspect}" if !adaptor.is_a?(Adaptors::Base)

--- a/lib/neo4j/core/cypher_session/adaptors.rb
+++ b/lib/neo4j/core/cypher_session/adaptors.rb
@@ -187,6 +187,16 @@ ERROR
               ("\n   ↳ #{source_line}:#{line_number}" if payload[:adaptor].options[:verbose_query_logs] && source_line).to_s
           end
 
+          def default_subscribe
+            subscribe_to_request
+          end
+
+          def close; end
+
+          def supports_metadata?
+            true
+          end
+
           class << self
             def transaction_class
               fail '.transaction_class method not implemented on adaptor!'

--- a/lib/neo4j/core/cypher_session/adaptors/embedded.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/embedded.rb
@@ -114,6 +114,10 @@ module Neo4j
           end
 
           def constraint_definitions_for(graph_db, label); end
+
+          def default_subscribe
+            subscribe_to_transaction
+          end
         end
       end
     end

--- a/lib/neo4j/core/cypher_session/adaptors/http.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/http.rb
@@ -145,6 +145,10 @@ module Neo4j
               request(:get, path, body, options)
             end
 
+            def supports_metadata?
+              version(_) >= '2.1.5'
+            end
+
             private
 
             def faraday_connection(configurator)

--- a/lib/neo4j/core/cypher_session/adaptors/schema.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/schema.rb
@@ -1,0 +1,34 @@
+module Neo4j
+  module Core
+    class CypherSession
+      module Adaptors
+        module Schema
+          def version(session)
+            result = query(session, 'CALL dbms.components()', {}, skip_instrumentation: true)
+
+            # BTW: community / enterprise could be retrieved via `result.first.edition`
+            result.first.versions[0]
+          end
+
+          def indexes(session)
+            result = query(session, 'CALL db.indexes()', {}, skip_instrumentation: true)
+
+            result.map do |row|
+              label, property = row.description.match(/INDEX ON :([^\(]+)\(([^\)]+)\)/)[1, 2]
+              {type: row.type.to_sym, label: label.to_sym, properties: [property.to_sym], state: row.state.to_sym}
+            end
+          end
+
+          def constraints(session)
+            result = query(session, 'CALL db.indexes()', {}, skip_instrumentation: true)
+
+            result.select { |row| row.type == 'node_unique_property' }.map do |row|
+              label, property = row.description.match(/INDEX ON :([^\(]+)\(([^\)]+)\)/)[1, 2]
+              {type: :uniqueness, label: label.to_sym, properties: [property.to_sym]}
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/neo4j-core.gemspec
+++ b/neo4j-core.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |s|
     Neo4j-core provides classes and methods to work with the graph database Neo4j.
 DESCRIPTION
 
-  s.require_path = 'lib'
+  s.require_paths = %w[lib spec]
   s.files = Dir.glob('{bin,lib,config}/**/*') + %w[README.md Gemfile neo4j-core.gemspec]
+  s.files += Dir['spec/neo4j/core/shared_examples/adaptor.rb', 'spec/neo4j_spec_helpers']
   s.has_rdoc = true
   s.extra_rdoc_files = %w[README.md]
   s.rdoc_options = ['--quiet', '--title', 'Neo4j::Core', '--line-numbers', '--main', 'README.rdoc', '--inline-source']

--- a/spec/neo4j/core/shared_examples/adaptor.rb
+++ b/spec/neo4j/core/shared_examples/adaptor.rb
@@ -29,13 +29,12 @@ RSpec.shared_examples 'Neo4j::Core::CypherSession::Adaptor' do
 
       expect(result[0].to_a[0].n).to be_a(Neo4j::Core::Node)
       expect(result[1].to_a[0].n).to be_a(Neo4j::Core::Node)
-      # Maybe should have method like adaptor.returns_node_and_relationship_metadata?
-      if adaptor.is_a?(::Neo4j::Core::CypherSession::Adaptors::HTTP) && adaptor.version(session_double) < '2.1.5'
-        expect(result[0].to_a[0].n.labels).to eq(nil)
-        expect(result[1].to_a[0].n.labels).to eq(nil)
-      else
+      if adaptor.supports_metadata?
         expect(result[0].to_a[0].n.labels).to eq([:Label1])
         expect(result[1].to_a[0].n.labels).to eq([:Label2])
+      else
+        expect(result[0].to_a[0].n.labels).to eq(nil)
+        expect(result[1].to_a[0].n.labels).to eq(nil)
       end
     end
 
@@ -45,11 +44,7 @@ RSpec.shared_examples 'Neo4j::Core::CypherSession::Adaptor' do
       end
 
       expect(result[0].to_a[0].n).to be_a(Neo4j::Core::Node)
-      if adaptor.is_a?(::Neo4j::Core::CypherSession::Adaptors::HTTP) && adaptor.version(session_double) < '2.1.5'
-        expect(result[0].to_a[0].n.labels).to eq(nil)
-      else
-        expect(result[0].to_a[0].n.labels).to eq([:Label1])
-      end
+      expect(result[0].to_a[0].n.labels).to eq(adaptor.supports_metadata? ? [:Label1] : nil)
     end
   end
 

--- a/spec/neo4j_spec_helpers.rb
+++ b/spec/neo4j_spec_helpers.rb
@@ -1,0 +1,32 @@
+module Neo4jSpecHelpers
+  class << self
+    attr_accessor :expect_queries_count
+  end
+
+  self.expect_queries_count = 0
+
+  Neo4j::Core::CypherSession::Adaptors::Base.subscribe_to_query do |_message|
+    self.expect_queries_count += 1
+  end
+
+  def expect_queries(count)
+    start_count = Neo4jSpecHelpers.expect_queries_count
+    yield
+    expect(Neo4jSpecHelpers.expect_queries_count - start_count).to eq(count)
+  end
+
+  def delete_schema(session = nil)
+    Neo4j::Core::Label.drop_uniqueness_constraints_for(session || current_session)
+    Neo4j::Core::Label.drop_indexes_for(session || current_session)
+  end
+
+  def create_constraint(session, label_name, property, options = {})
+    label_object = Neo4j::Core::Label.new(label_name, session)
+    label_object.create_constraint(property, options)
+  end
+
+  def create_index(session, label_name, property, options = {})
+    label_object = Neo4j::Core::Label.new(label_name, session)
+    label_object.create_index(property, options)
+  end
+end


### PR DESCRIPTION
Fixes #
This is a neutral PR that does not introduce any new functionality. It does some refactoring and cleanup and exposes hook methods that are necessary for the java driver adaptor to work properly.
This pull introduces/changes:
 * adds `close` methods on driver and session
 * packs shared spec example and a spec helper into the gem for reuse by adaptors in separate gems




Pings:
@cheerfulstoic
@subvertallchris
