### PR TITLE
Implement Bolt Routing protocol (closes #322).

### DIFF
--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -28,7 +28,7 @@ module Neo4j
             @net_tcp_client_options = {read_timeout: options.fetch(:read_timeout, -1),
                                        write_timeout: options.fetch(:write_timeout, -1),
                                        connect_timeout: options.fetch(:connect_timeout, 10),
-                                       ssl: options.fetch(:ssl, {})}
+                                       ssl: options.fetch(:ssl, false)}
 
             open_socket
           end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt/pack_stream.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt/pack_stream.rb
@@ -1,4 +1,5 @@
 require 'stringio'
+require 'active_support/hash_with_indifferent_access'
 
 module Neo4j
   module Core
@@ -67,7 +68,8 @@ module Neo4j
           else
             case @object
             when Date, Time, DateTime then string_stream
-            when Integer, Float, String, Symbol, Array, Set, Structure, Hash
+            when Hash, HashWithIndifferentAccess then hash_stream
+            when Integer, Float, String, Symbol, Array, Set, Structure
               send(@object.class.name.split('::').last.downcase + '_stream')
             end
           end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing.rb
@@ -1,48 +1,221 @@
 # frozen_string_literal: true
 
+require 'concurrent'
+require 'concurrent-edge'
+require 'io/wait'
+require 'socket'
 require 'neo4j/core/cypher_session/adaptors'
 require 'neo4j/core/cypher_session/adaptors/has_uri'
 require 'neo4j/core/cypher_session/adaptors/bolt/pack_stream'
-require 'neo4j/core/cypher_session/adaptors/bolt/chunk_writer_io'
-require 'neo4j/core/cypher_session/responses/bolt'
+require 'neo4j/core/cypher_session/responses/bolt_routing'
+require 'neo4j/core/cypher_session/adaptors/bolt_routing/dns_host_name_resolver'
 require 'neo4j/core/cypher_session/adaptors/bolt_routing/load_balancing_strategies'
 require 'neo4j/core/cypher_session/adaptors/bolt_routing/load_balancer'
 require 'neo4j/core/cypher_session/adaptors/bolt_routing/pool'
-require 'io/wait'
-require 'socket'
 
 module Neo4j
   module Core
     class CypherSession
       module Adaptors
-        class BoltRouting < Base
+        class BoltRouting < Bolt
+          include Adaptors::HasUri
+
           SUPPORTED_VERSIONS = [1, 0, 0, 0].freeze
+
           VERSION = '0.0.1'.freeze
 
-          def initialize(url = 'bolt+routing://neo4:neo4j@localhost:7687', routing_context = nil, options = {})
-            uri = URI(url)
-            @host_port = "#{ uri.host }:#{ uri.port }"
+          default_url('bolt+routing://neo4:neo4j@localhost:7687')
+
+          validate_uri do |uri|
+            uri.scheme == 'bolt+routing'
+          end
+
+          def initialize(url, options = {})
+            self.url = url
+
+            @host_port = "#{ host }:#{ port }"
             @options = options
-            @routing_context = routing_context
-            @url = url
+            @routing_context = @uri.query
             @net_tcp_client_options = {
               connect_timeout: options.fetch(:connect_timeout, 10),
               read_timeout: options.fetch(:read_timeout, -1),
-              ssl: options.fetch(:ssl, {}),
+              ssl: options.fetch(:ssl, false),
               write_timeout: options.fetch(:write_timeout, -1),
             }
           end
 
+          def connect; end
+
+          # FIXME: Drive this down to the connection pool or track active
+          # connections in the adapter.
+          def connected?
+            true
+          end
+
+          # FIXME: Drive this down to the connection pool or track active
+          # connections in the adapter.
+          def ssl?
+            !!@options.fetch(:ssl, false)
+          end
+
+          def query_set(transaction, queries, options = {})
+            setup_queries!(queries, transaction, skip_instrumentation: options[:skip_instrumentation])
+
+            write_queries = queries.select { |q| /(BEGIN|COMMIT|CREATE|DELETE|DETACH|SET|REMOVE|ROLLBACK|FOREACH|MERGE|CALL)/.match?(q.cypher) }
+            read_queries = queries - write_queries
+
+            write_conn = if write_queries.empty?
+                           Concurrent::Promises.fulfilled_future(nil)
+                         elsif !transaction.connection.nil?
+                           Concurrent::Promises.fulfilled_future(transaction.connection).then(write_queries, options) do |conn, write_queries, options|
+                             self.class.instrument_request(self) do
+                               send_query_jobs(conn, write_queries)
+                               build_response(write_queries, conn, options[:wrap_level] || @options[:wrap_level])
+                             end
+                           end
+                         else
+                           connection_provider.acquire_connection(:write).then(write_queries, options, transaction) do |conn, write_queries, options, transaction|
+                             transaction.connection = conn
+                             self.class.instrument_request(self) do
+                               send_query_jobs(conn, write_queries)
+                               build_response(write_queries, conn, options[:wrap_level] || @options[:wrap_level])
+                             end
+                           end
+                         end
+            read_conn = if read_queries.empty?
+                          Concurrent::Promises.fulfilled_future(nil)
+                        elsif !transaction.connection.nil?
+                          Concurrent::Promises.fulfilled_future(transaction.connection).then(read_queries, options) do |conn, read_queries, options|
+                            self.class.instrument_request(self) do
+                              send_query_jobs(conn, read_queries)
+                              build_response(read_queries, conn, options[:wrap_level] || @options[:wrap_level])
+                            end
+                          end
+                        else
+                          connection_provider.acquire_connection(:read).then(read_queries, options, transaction) do |conn, read_queries, options, transaction|
+                            transaction.connection = conn
+                            self.class.instrument_request(self) do
+                              send_query_jobs(conn, read_queries)
+                              build_response(read_queries, conn, options[:wrap_level] || @options[:wrap_level])
+                            end
+                          end
+                        end
+
+            (write_conn & read_conn).then do |w, r|
+              responses = []
+              responses += w unless w.nil?
+              responses += r unless r.nil?
+              responses
+            end.value!
+          end
+
+          def self.transaction_class
+            require 'neo4j/core/cypher_session/transactions/bolt_routing'
+            Neo4j::Core::CypherSession::Transactions::BoltRouting
+          end
+
           private
 
-          attr_reader :options, :routing_context
+          BYTE_STRINGS = (0..255).map { |byte| byte.to_s(16).rjust(2, '0') }
+
+          GOGOBOLT = "\x60\x60\xB0\x17"
+
+          STREAM_INSPECTOR = lambda do |stream|
+            stream.bytes.map { |byte| BYTE_STRINGS[byte] }.join(':')
+          end
+
+          attr_reader :host_port, :routing_context
+
+          def build_response(queries, client, wrap_level)
+            catch(:cypher_bolt_failure) do
+              Responses::BoltRouting.new(queries, client, method(:flush_messages), wrap_level: wrap_level).results
+            end.tap do |error_data|
+              handle_failure(client, error_data) unless error_data.is_a?(Array)
+            end
+          end
+
+          def close_socket(client)
+            client.close
+          end
+
+          def connect_socket(host_port, release)
+            client = open_socket(host_port)
+
+            handshake(client)
+
+            init(client)
+
+            message = flush_messages(client)[0]
+            return client if message.type == :success
+
+            data = message.args[0]
+            logger.error { "Init did not complete successfully\n\n#{data['code']}\n#{data['message']}" }
+            release.call(host_port, client)
+            nil
+          end
 
           def connection_provider
+            @connection_provider ||= Neo4j::Core::BoltRouting::LoadBalancer.new(host_port, routing_context, pool, load_balancing_strategy, resolver)
+          end
 
+          def flush_messages(client)
+            if structures = flush_response(client)
+              structures.map do |structure|
+                Message.new(structure.signature, *structure.list).tap do |message|
+                  log_message :S, message.type, message.args.join(' ') if logger.debug?
+                end
+              end
+            end
+          end
+
+          def flush_response(client)
+            chunk = String.new
+
+            while !(header = recvmsg(client, 2)).empty? && (chunk_size = header.unpack('s>*')[0]) > 0
+              log_message :S, :chunk_size, chunk_size
+
+              chunk << recvmsg(client, chunk_size)
+            end
+
+            unpacker = PackStream::Unpacker.new(StringIO.new(chunk))
+            [].tap { |r| while arg = unpacker.unpack_value!; r << arg; end }
+          end
+
+          def handshake(client)
+            log_message :C, :handshake, nil
+
+            sendmsg(client, GOGOBOLT + SUPPORTED_VERSIONS.pack('l>*'))
+
+            agreed_version = recvmsg(client, 4).unpack('l>*')[0]
+
+            if agreed_version.zero?
+              client.close
+              logger.error { "Couldn't agree on a version (Sent versions #{SUPPORTED_VERSIONS.inspect})" }
+            end
+
+            logger.debug { "Agreed to version: #{agreed_version}" }
+          end
+
+          def handle_failure(client, error_data)
+            flush_messages(client)
+
+            send_job(client) do |job|
+              job.add_message(:ack_failure)
+            end
+
+            fail 'Excepted SUCCESS for ACK_FAILURE' if flush_messages(client)[0].type != :success
+
+            fail CypherError.new_from(error_data['code'], error_data['message'])
+          end
+
+          def init(client)
+            send_job(client) do |job|
+              job.add_message(:init, USER_AGENT_STRING, principal: user, credentials: password, scheme: 'basic')
+            end
           end
 
           def load_balancing_strategy
-            @load_balancing_strategy ||= do
+            @load_balancing_strategy ||= begin
                                            strategy = @options.fetch(:load_balancing_strategy, :least_connected).to_sym
                                            return Neo4j::Core::BoltRouting::RoundRobinLoadBalancingStrategy.new(pool) if strategy == :round_robin
                                            return Neo4j::Core::BoltRouting::LeastConenctedLoadBalancingStrategy.new(pool) if strategy == :least_connected
@@ -57,11 +230,45 @@ module Neo4j
           end
 
           def pool
-            @pool ||=Neo4j::Core::BoltRouting::Pool.new create: method(:open_socket)
+            @pool ||= Neo4j::Core::BoltRouting::Pool.new create: method(:connect_socket),
+                                                         destroy: method(:close_socket),
+                                                         validate: method(:validate_socket)
+          end
+
+          def recvmsg(client, size)
+            client.read(size) do |result|
+              log_message :S, result
+            end
           end
 
           def resolver
             @resolver ||= Neo4j::Core::BoltRouting::DNSHostNameResolver.new
+          end
+
+          def send_job(client)
+            new_job.tap do |job|
+              yield job
+              log_message :C, :job, job
+              sendmsg(client, job.chunked_packed_stream)
+            end
+          end
+
+          def send_query_jobs(client, queries)
+            send_job(client) do |job|
+              queries.each do |query|
+                job.add_message(:run, query.cypher, query.parameters || {})
+                job.add_message(:pull_all)
+              end
+            end
+          end
+
+          def sendmsg(client, message)
+            log_message :C, message
+            client.write(message)
+          end
+
+          def validate_socket(client)
+            client.alive?
           end
         end
       end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'neo4j/core/cypher_session/adaptors'
+require 'neo4j/core/cypher_session/adaptors/has_uri'
+require 'neo4j/core/cypher_session/adaptors/bolt/pack_stream'
+require 'neo4j/core/cypher_session/adaptors/bolt/chunk_writer_io'
+require 'neo4j/core/cypher_session/responses/bolt'
+require 'neo4j/core/cypher_session/adaptors/bolt_routing/load_balancing_strategies'
+require 'neo4j/core/cypher_session/adaptors/bolt_routing/load_balancer'
+require 'neo4j/core/cypher_session/adaptors/bolt_routing/pool'
+require 'io/wait'
+require 'socket'
+
+module Neo4j
+  module Core
+    class CypherSession
+      module Adaptors
+        class BoltRouting < Base
+          SUPPORTED_VERSIONS = [1, 0, 0, 0].freeze
+          VERSION = '0.0.1'.freeze
+
+          def initialize(url = 'bolt+routing://neo4:neo4j@localhost:7687', routing_context = nil, options = {})
+            uri = URI(url)
+            @host_port = "#{ uri.host }:#{ uri.port }"
+            @options = options
+            @routing_context = routing_context
+            @url = url
+            @net_tcp_client_options = {
+              connect_timeout: options.fetch(:connect_timeout, 10),
+              read_timeout: options.fetch(:read_timeout, -1),
+              ssl: options.fetch(:ssl, {}),
+              write_timeout: options.fetch(:write_timeout, -1),
+            }
+          end
+
+          private
+
+          attr_reader :options, :routing_context
+
+          def connection_provider
+
+          end
+
+          def load_balancing_strategy
+            @load_balancing_strategy ||= do
+                                           strategy = @options.fetch(:load_balancing_strategy, :least_connected).to_sym
+                                           return Neo4j::Core::BoltRouting::RoundRobinLoadBalancingStrategy.new(pool) if strategy == :round_robin
+                                           return Neo4j::Core::BoltRouting::LeastConenctedLoadBalancingStrategy.new(pool) if strategy == :least_connected
+                                           raise ArgumentError, "Unknown load balancing strategy: `#{ strategy }`."
+                                         end
+          end
+
+          def open_socket(host_port)
+            Net::TCPClient.new(@net_tcp_client_options.merge(buffered: false, server: host_port))
+          rescue Errno::ECONNREFUSED => e
+            raise Neo4j::Core::CypherSession::ConnectionFailedError, e.message
+          end
+
+          def pool
+            @pool ||=Neo4j::Core::BoltRouting::Pool.new create: method(:open_socket)
+          end
+
+          def resolver
+            @resolver ||= Neo4j::Core::BoltRouting::DNSHostNameResolver.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing.rb
@@ -58,7 +58,7 @@ module Neo4j
 
             query_builder.instance_eval(&block)
 
-            write_queries = query_builder.queries.count { |q| /(CREATE|DELETE|DETACH|SET|REMOVE|FOREACH|MERGE|CALL)/.match?(q.cypher) }
+            write_queries = query_builder.queries.count { |q| /(CREATE|DELETE|DETACH|DROP|SET|REMOVE|FOREACH|MERGE|CALL)/.match?(q.cypher) }
             access_mode = write_queries.zero? ? :read : :write
 
             new_or_current_transaction(session, access_mode, options[:transaction]) do |tx|

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/connection.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/connection.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Core
+    module BoltRouting
+      class Connection
+        attr_reader :client
+
+        def initialize(host_port, client, release)
+          @host_port = host_port
+          @client = client
+          @release = release
+        end
+
+        def release
+          @release.call(@host_port, self)
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/dns_host_name_resolver.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/dns_host_name_resolver.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Core
+    module BoltRouting
+      class DNSHostNameResolver
+        def resolve(seed_router)
+          parsed_uri = URI(seed_router)
+          Resolv.getaddresses(parsed_uri.host)
+        rescue
+          [seed_router]
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/dns_host_name_resolver.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/dns_host_name_resolver.rb
@@ -1,14 +1,32 @@
 # frozen_string_literal: true
 
+require 'resolv'
+
 module Neo4j
   module Core
     module BoltRouting
       class DNSHostNameResolver
         def resolve(seed_router)
-          parsed_uri = URI(seed_router)
-          Resolv.getaddresses(parsed_uri.host)
-        rescue
-          [seed_router]
+          host, port = seed_router.split(':')
+
+          Concurrent::Promises.future(host, port, seed_router) do |host, port, seed_router|
+            begin
+              resolver = Resolv::DNS.new
+              addresses = resolver.getaddresses(host)
+
+              addresses.map do |address|
+                if address.is_a?(Resolv::IPv6)
+                  "[#{ address.to_s }]:#{ port }"
+                elsif address.is_a?(Resolv::IPv4)
+                  "#{ address.to_s }:#{ port }"
+                else
+                  raise "Unknown address type: #{ address }."
+                end
+              end
+            rescue
+              [seed_router]
+            end
+          end
         end
       end
     end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/load_balancer.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/load_balancer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'neo4j/core/cypher_session/adaptors/single_connection'
 require 'neo4j/core/cypher_session/adaptors/bolt_routing/rediscovery'
 require 'neo4j/core/cypher_session/adaptors/bolt_routing/routing_table'
 
@@ -7,6 +8,13 @@ module Neo4j
   module Core
     module BoltRouting
       class LoadBalancer
+        UNAUTHORIZED_ERROR_CODE = 'Neo.ClientError.Security.Unauthorized'
+
+        def self.forget_router(routing_table, routers_array, router_index)
+          address = routers_array[router_index]
+          routing_table.forget_router(address) if routing_table && address
+        end
+
         def initialize(host_port, routing_context, connection_pool, load_balancing_strategy, host_name_resolver)
           @seed_router = host_port
           @routing_context = routing_context
@@ -17,28 +25,133 @@ module Neo4j
         end
 
         def acquire_connection(access_mode)
+          fresh_routing_table(access_mode).then(access_mode) do |routing_table, access_mode|
+            if access_mode == :read
+              address = load_balancing_strategy.select_reader(routing_table.readers)
+              acquire_connection_to_server(address, 'read')
+            elsif access_mode == :write
+              address = load_balancing_strategy.select_writer(routing_table.writers)
+              acquire_connection_to_server(address, 'write')
+            else
+              raise ArgumentError, "Illegal access mode: #{ access_mode }."
+            end
+          end.flat
+        end
+
+        def forget(address)
+          routing_table.forget(address)
+          connection_pool.purge(address)
+        end
+
+        def forget_writer(address)
+          routing_table.forget_writer(address)
         end
 
         private
 
         attr_reader :connection_pool, :host_name_resolver, :load_balancing_strategy, :routing_context, :seed_router
 
+        def acquire_connection_to_server(address, server_name)
+          return Concurrent::Promises.rejected_future(StandardError.new("Failed to obtain connection towards #{ server_name } server. Known routing table is #{ routing_table.inspect }.")) if address.nil?
+          connection_pool.acquire(address)
+        end
+
+        def apply_routing_table_if_possible!(new_routing_table)
+          raise Neo4j::Core::CypherSession::ConnectionFailedError, "Could not perform discovery. No routing servers available. Known routing table: #{ routing_table.inspect }." if new_routing_table.nil?
+
+          current_routing_table = routing_table
+
+          @use_seed_router = true if new_routing_table.writers.empty?
+
+          stale_servers = current_routing_table - new_routing_table
+          stale_servers.each { |ss| connection_pool.purge(ss) }
+
+          @routing_table = new_routing_table
+        end
+
+        def create_session_for_rediscovery(router_address)
+          connection_pool.acquire(router_address).then do |connection|
+            Neo4j::Core::CypherSession.new Neo4j::Core::CypherSession::Adaptors::SingleConnection.new(connection)
+          end.rescue do |error|
+            raise error if error.respond_to?(:code) && error.code == UNAUTHORIZED_ERROR_CODE
+            nil
+          end
+        end
+
         def fetch_routing_table(router_addresses, routing_table = nil)
+          router_addresses.each_with_index.reduce(Concurrent::Promises.fulfilled_future(nil)) do |refreshed_table_promise, (current_router, current_index)|
+            refreshed_table_promise.then(router_addresses, routing_table, current_router, current_index) do |new_routing_table, router_address, routing_table, current_router, current_index|
+              if new_routing_table.nil?
+                previous_router_index = current_index - 1
+                LoadBalancer.forget_router(routing_table, router_addresses, previous_router_index)
+
+                create_session_for_rediscovery(current_router).then(current_router) do |session, current_router|
+                  if session.nil?
+                    nil
+                  else
+                    rediscovery.look_up_routing_table_on_router(session, current_router)
+                  end
+                end
+              else
+                new_routing_table
+              end
+            end
+          end
         end
 
         def fetch_routing_table_from_seed_or_known
-          seen_routers = []
-          new_routing_table = fetch_routing_table_using_seed(seen_routers)
+          seen_routers = Concurrent::Array.new
+          fetch_routing_table_using_seed(seen_routers).then do |new_routing_table|
+            if new_routing_table.nil?
+              fetch_routing_table_using_known
+            else
+              @use_seed_router = false
+              new_routing_table
+            end
+          end.flat.then do |new_routing_table|
+            apply_routing_table_if_possible!(new_routing_table)
+            new_routing_table
+          end
+        end
+
+        def fetch_routing_table_from_known_or_seed
+          fetch_routing_table_using_known.then do |new_routing_table|
+            if new_routing_table.nil?
+              fetch_routing_table_using_seed(routing_table.routers)
+            else
+              new_routing_table
+            end
+          end.flat.then do |new_routing_table|
+            apply_routing_table_if_possible!(new_routing_table)
+            new_routing_table
+          end
+        end
+
+        def fetch_routing_table_using_known
+          known_routers = routing_table.routers
+
+          fetch_routing_table(known_routers, routing_table).then(known_routers) do |new_routing_table, known_routers|
+            if new_routing_table.nil?
+              last_router_index = known_routers.size - 1
+              LoadBalancer.forget_router(routing_table, known_routers, last_router_index)
+
+              nil
+            else
+              new_routing_table
+            end
+          end
         end
 
         def fetch_routing_table_using_seed(seen_routers)
           resolved_addresses = host_name_resolver.resolve(seed_router)
-          new_addresses = resolved_addresses - seen_routers
-          fetch_routing_table(new_addresses)
+          resolved_addresses.then(seen_routers) do |router_addresses, seen_routers|
+            new_addresses = router_addresses - seen_routers
+            fetch_routing_table(new_addresses)
+          end
         end
 
         def fresh_routing_table(access_mode)
-          return routing_table unless routing_table.is_stale_for(access_mode)
+          return Concurrent::Promises.fulfilled_future(routing_table) unless routing_table.stale_for?(access_mode)
 
           refresh_routing_table!
         end
@@ -48,9 +161,11 @@ module Neo4j
         end
 
         def refresh_routing_table!
-          return fetch_routing_table_from_seed_or_known if @use_seed_router
-
-          fech_routing_table_from_known_or_seed
+          if @use_seed_router
+            fetch_routing_table_from_seed_or_known
+          else
+            fetch_routing_table_from_known_or_seed
+          end
         end
 
         def routing_table

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/load_balancer.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/load_balancer.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'neo4j/core/cypher_session/adaptors/bolt_routing/rediscovery'
+require 'neo4j/core/cypher_session/adaptors/bolt_routing/routing_table'
+
+module Neo4j
+  module Core
+    module BoltRouting
+      class LoadBalancer
+        def initialize(host_port, routing_context, connection_pool, load_balancing_strategy, host_name_resolver)
+          @seed_router = host_port
+          @routing_context = routing_context
+          @connection_pool = connection_pool
+          @load_balancing_strategy = load_balancing_strategy
+          @host_name_resolver = host_name_resolver
+          @use_seed_router = false
+        end
+
+        def acquire_connection(access_mode)
+        end
+
+        private
+
+        attr_reader :connection_pool, :host_name_resolver, :load_balancing_strategy, :routing_context, :seed_router
+
+        def fetch_routing_table(router_addresses, routing_table = nil)
+        end
+
+        def fetch_routing_table_from_seed_or_known
+          seen_routers = []
+          new_routing_table = fetch_routing_table_using_seed(seen_routers)
+        end
+
+        def fetch_routing_table_using_seed(seen_routers)
+          resolved_addresses = host_name_resolver.resolve(seed_router)
+          new_addresses = resolved_addresses - seen_routers
+          fetch_routing_table(new_addresses)
+        end
+
+        def fresh_routing_table(access_mode)
+          return routing_table unless routing_table.is_stale_for(access_mode)
+
+          refresh_routing_table!
+        end
+
+        def rediscovery
+          @rediscovery ||= Rediscovery.new(@routing_context)
+        end
+
+        def refresh_routing_table!
+          return fetch_routing_table_from_seed_or_known if @use_seed_router
+
+          fech_routing_table_from_known_or_seed
+        end
+
+        def routing_table
+          @routing_table ||= RoutingTable.new([@seed_router])
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/load_balancing_strategies.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/load_balancing_strategies.rb
@@ -45,7 +45,7 @@ module Neo4j
             if index == addresses.size - 1
               index = 0
             else
-              index++
+              index += 1
             end
 
             break if index == start_index

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/load_balancing_strategies.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/load_balancing_strategies.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'neo4j/core/cypher_session/adaptors/bolt_routing/round_robin_array_index'
+
+module Neo4j
+  module Core
+    module BoltRouting
+      class LeastConenctedLoadBalancingStrategy
+        def initialize(pool)
+          @pool = pool
+          @readers = RoundRobinArrayIndex.new
+          @writers = RoundRobinArrayIndex.new
+        end
+
+        def select_reader(known_readers)
+          select(known_readers, readers)
+        end
+
+        def select_writer(known_writers)
+          select(known_writers, writers)
+        end
+
+        private
+
+        attr_reader :pool, :readers, :writers
+
+        def select(addresses, round_robin_index)
+          return if addresses.empty?
+
+          start_index = round_robin_index.next(addresses.size)
+          index = start_index
+
+          least_connected_address = nil
+          least_active_connections = BigDecimal('Infinity')
+
+          loop do
+            address = addresses[index]
+            active_connections = pool.active_resource_count(address)
+
+            if active_connections < least_active_connections
+              least_connected_address = address
+              least_active_connections = active_connections
+            end
+
+            if index == addresses.size - 1
+              index = 0
+            else
+              index++
+            end
+
+            break if index == start_index
+          end
+
+          least_connected_address
+        end
+      end
+    end
+
+    class RoundRobinLoadBalancingStrategy
+      def initialize(pool)
+        @pool = pool
+        @readers = RoundRobinArrayIndex.new
+        @writers = RoundRobinArrayIndex.new
+      end
+
+      def select_reader(known_readers)
+        select(known_readers, readers)
+      end
+
+      def select_writer(known_writers)
+        select(known_writers, writers)
+      end
+
+      private
+
+      attr_reader :pool, :readers, :writers
+
+      def select(addresses, round_robin_index)
+        return if addresses.empty?
+
+        index = round_robin_index.next(addresses.size)
+        addresses[index]
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/pool.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/pool.rb
@@ -4,56 +4,164 @@ module Neo4j
   module Core
     module BoltRouting
       class Pool
-        def initialize(config: {}, create:)
+        def initialize(config: {}, create:, destroy: ->(resource) { true }, validate: ->(resource) { true })
           @acquisition_timeout = config.fetch(:acquisition_timeout, 60)
+          @max_size = config.fetch(:max_size, 100)
           @create = create
           @destroy = destroy
-          @max_size = config.fetch(:max_size, 100)
-          @pools = {}
           @validate = validate
+          @active_resource_counts = Concurrent::Map.new
+          @acquire_requests = Concurrent::Map.new
+          @pools = Concurrent::Map.new
         end
 
         def active_resource_count(key)
-          pool = @pools[key]
-
-          return 0 if pool.nil?
-
-          pool.size - pool.available
+          @active_resource_counts[key] || 0
         end
 
         def acquire(key)
-          acquire_resource(key) do |conn|
-            yield conn
+          acquire_resource(key).then do |resource|
+            if resource.nil?
+              @acquire_requests[key] ||= Concurrent::Array.new
+              cancellation, token = Concurrent::Cancellation.create
+              future = Concurrent::Promises.resolvable_future
+              request = PendingRequest.new(future, cancellation)
+              @acquire_requests[key] << request
+
+              timeout = Concurrent::Promises.schedule(@acquisition_timeout, request, token) do
+                unless token.canceled?
+                  @acquire_requests[key].delete(request)
+
+                  request.reject(Neo4j::Core::CypherSession::ConnectionFailedError.new("Connection acquisition timed out after #{ @acquisition_timeout }ms."))
+                end
+              end
+
+              future | timeout
+            else
+              resource_acquired!(key)
+              resource
+            end
           end
         end
 
         def has(key)
-          !@pools[key].nil?
+          @pools.has_key?(key)
         end
 
         def purge(key)
           pool = @pools[key]
-          pool.shutdown { |conn| conn.close }
+
+          while !pool.size.zero?
+            resource = pool.pop
+            @destroy.call(resource)
+          end
+
           @pools.delete(key)
         end
 
         def purge_all
-          @pools.each { |key, _value| purge(key) }
+          @pools.each { |key| purge(key) }
         end
 
         private
 
         def acquire_resource(key)
           pool = @pools[key]
+
           if pool.nil?
-            pool = ConnectionPool.new(size: @max_size, timeout: @acquisition_timeout) do
-              @create.call(key)
-            end
+            pool = Concurrent::Array.new
             @pools[key] = pool
           end
 
-          pool.with do |conn|
-            yield conn
+          while !pool.size.zero?
+            resource = pool.pop
+
+            if @validate.call(resource)
+              Concurrent::Promises.fulfilled_future(resource)
+            else
+              @destroy.call(resource)
+            end
+          end
+
+          return Concurrent::Promises.fulfilled_future(nil) if !@max_size.nil? && active_resource_count(key) >= @max_size
+
+          Concurrent::Promises.fulfilled_future(@create.call(key, method(:release)))
+        end
+
+        def process_pending_acquire_requests!(key)
+          requests = @acquire_requests[key]
+
+          unless requests.nil?
+            pending_request = requests.shift
+
+            return @acquire_requests.delete(key) if pending_request.nil?
+
+            acquire_resource(key).rescue(pending_request) do |error, pending_request|
+              pending_request.reject(error)
+              nil
+            end.then(key, pending_request) do |resource, key, pending_request|
+              return if resource.nil?
+              return release(key, resource) if pending_request.completed?
+
+              resource_acquired!(key)
+              pending_request.resolve(resource)
+            end
+          end
+        end
+
+        def release(key, resource)
+          pool = @pools[key]
+
+          if pool.nil?
+            @destroy.call(resource)
+          else
+            if @validate.call(resource)
+              pool << resource
+            else
+              @destroy.call(resource)
+            end
+          end
+
+          resource_released!(key)
+
+          process_pending_acquire_requests!(key)
+        end
+
+        def resource_acquired!(key)
+          @active_resource_counts[key] ||= 0
+          @active_resource_counts[key] += 1
+        end
+
+        def resource_released!(key)
+          @active_resource_counts[key] -= 1
+          @active_resource_counts.delete(key) if @active_resource_counts[key] <= 0
+        end
+
+        class PendingRequest
+          def initialize(future, cancellation)
+            @future = future
+            @cancellation = cancellation
+            @completed = false
+          end
+
+          def completed?
+            @completed
+          end
+
+          def reject(error)
+            return if completed?
+
+            @completed = true
+            @cancellation.cancel
+            @future.reject(error)
+          end
+
+          def resolve(resource)
+            return if completed?
+
+            @completed = true
+            @cancellation.cancel
+            @future.resolve(resource)
           end
         end
       end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/pool.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/pool.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Core
+    module BoltRouting
+      class Pool
+        def initialize(config: {}, create:)
+          @acquisition_timeout = config.fetch(:acquisition_timeout, 60)
+          @create = create
+          @destroy = destroy
+          @max_size = config.fetch(:max_size, 100)
+          @pools = {}
+          @validate = validate
+        end
+
+        def active_resource_count(key)
+          pool = @pools[key]
+
+          return 0 if pool.nil?
+
+          pool.size - pool.available
+        end
+
+        def acquire(key)
+          acquire_resource(key) do |conn|
+            yield conn
+          end
+        end
+
+        def has(key)
+          !@pools[key].nil?
+        end
+
+        def purge(key)
+          pool = @pools[key]
+          pool.shutdown { |conn| conn.close }
+          @pools.delete(key)
+        end
+
+        def purge_all
+          @pools.each { |key, _value| purge(key) }
+        end
+
+        private
+
+        def acquire_resource(key)
+          pool = @pools[key]
+          if pool.nil?
+            pool = ConnectionPool.new(size: @max_size, timeout: @acquisition_timeout) do
+              @create.call(key)
+            end
+            @pools[key] = pool
+          end
+
+          pool.with do |conn|
+            yield conn
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/pool.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/pool.rb
@@ -100,11 +100,14 @@ module Neo4j
               pending_request.reject(error)
               nil
             end.then(key, pending_request) do |resource, key, pending_request|
-              return if resource.nil?
-              return release(key, resource) if pending_request.completed?
-
-              resource_acquired!(key)
-              pending_request.resolve(resource)
+              if resource.nil?
+                nil
+              elsif pending_request.completed?
+                release(key, resource)
+              else
+                resource_acquired!(key)
+                pending_request.resolve(resource)
+              end
             end
           end
         end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/rediscovery.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/rediscovery.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'neo4j/core/cypher_session/adaptors/bolt_routing/routing_table'
+require 'neo4j/core/cypher_session/adaptors/bolt_routing/routing_util'
+
+module Neo4j
+  module Core
+    module BoltRouting
+      class Rediscovery
+        def self.assert_not_empty(server_addresses, servers_name, router_address)
+          raise ArgumentError, "Received no #{ servers_name } from router #{ router_address }." if server_addresses.empty?
+        end
+
+        def initialize(routing_context)
+          @routing_context = routing_context
+        end
+
+        def look_up_routing_table_on_router(session, router_address)
+          records = routing_util.call_routing_procedure(session, router_address)
+
+          return unless records
+          raise ArgumentError, "Illegal response from router #{ router_address }. Received #{ records.size } records but only expected one." unless records.size == 1
+
+          record = records.first
+
+          expiration_time = routing_util.parse_ttl(record, router_address)
+          servers = routing_util.parse_servers(record, router_address)
+
+          Rediscovery.assert_not_empty(servers[:routers], 'routers', router_address)
+          Rediscovery.assert_not_empty(servers[:readers], 'readers', router_address)
+
+          RoutingTable.new(servers[:routers], servers[:readers], servers[:writers], expiration_time)
+        end
+
+        private
+
+        def routing_util
+          @routing_util ||= RoutingUtil.new(@routing_context)
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/rediscovery.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/rediscovery.rb
@@ -19,9 +19,9 @@ module Neo4j
           records = routing_util.call_routing_procedure(session, router_address)
 
           return unless records
-          raise ArgumentError, "Illegal response from router #{ router_address }. Received #{ records.size } records but only expected one." unless records.size == 1
+          raise ArgumentError, "Illegal response from router #{ router_address }. Received #{ records.hashes.size } records but only expected one." unless records.hashes.size == 1
 
-          record = records.first
+          record = records.hashes.first
 
           expiration_time = routing_util.parse_ttl(record, router_address)
           servers = routing_util.parse_servers(record, router_address)

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/round_robin_array_index.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/round_robin_array_index.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Core
+    module BoltRouting
+      class RoundRobinArrayIndex
+        def initialize(offset = 0)
+          @offset = offset
+        end
+
+        def next(array_length)
+          return -1 if array_length.zero?
+
+          next_offset = @offset
+          @offset += 1
+
+          next_offset % array_length
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/routing_table.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/routing_table.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Core
+    module BoltRouting
+      class RoutingTable
+        MIN_ROUTERS = 1
+
+        attr_reader :routers, :readers, :writers, :expiration_time
+
+        def initialize(routers = [], readers = [], writers = [], expiration_time = 0)
+          @routers = routers
+          @readers = readers
+          @writers = writers
+          @expiration_time = expiration_time
+        end
+
+        def inspect
+          "#<RoutingTable [@expiration_time=#{ expiration_time }, current_time=#{ Time.now.to_i }, @routers=[#{ routers.join(', ') }], @readers=[#{ readers.join(', ') }], @writers=[#{ writers.join(', ') }]]>"
+        end
+
+        def -(other_routing_table)
+          all_servers - other_routing_table.all_servers
+        end
+
+        def all_servers
+          (routers + readers + writers).uniq
+        end
+
+        def forget(address)
+          @readers.delete(address)
+          @writers.delete(address)
+        end
+
+        def forget_router(address)
+          @routers.delete(address)
+        end
+
+        def forget_writer(address)
+          @writers.delete(address)
+        end
+
+        def stale_for?(access_mode)
+          expiration_time < Time.now.to_i ||
+            routers.size < MIN_ROUTERS ||
+            (access_mode == :read && readers.empty?) ||
+            (access_mode == :write && writers.empty?)
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/bolt_routing/routing_util.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt_routing/routing_util.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Core
+    module BoltRouting
+      class RoutingUtil
+        CALL_GET_ROUTING_TABLE = 'CALL dbms.cluster.routing.getRoutingTable({context})'
+        CALL_GET_SERVERS = 'CALL dbms.cluster.routing.getServers'
+        PROCEDURE_NOT_FOUND_CODE = 'Neo.ClientError.Procedure.ProcedureNotFound'
+
+        def initialize(routing_context)
+          @routing_context = routing_context
+        end
+
+        def call_routing_procedure(session, router_address)
+          call_available_routing_procedure(session) do |result|
+            result
+          end
+        rescue => e
+          raise Neo4j::Core::CypherSession::CypherError::ConnectionFailedError, "Server at #{ router_address } cannot perform routing. Make sure you are connecting to a causal cluster." if e.code == PROCEDURE_NOT_FOUND_CODE
+        end
+
+        def parse_servers(record, router_address)
+          servers = record.properties[:servers]
+
+          readers = []
+          routers = []
+          writers = []
+
+          servers.each do |server|
+            role = server[:role]
+            addresses = server[:addresses]
+
+            if role == 'ROUTE'
+              routers += addresses.to_a
+            elsif role == 'WRITE'
+              writers += addresses.to_a
+            elsif role == 'READ'
+              readers += addresses.to_a
+            else
+              raise ArgumentError, "Unknown server role: `#{ role }`."
+            end
+          end
+
+          {
+            readers: readers,
+            routers: routers,
+            writers: writers,
+          }
+        rescue => e
+          raise Neo4j::Core::CypherSession::CypherError::ConnectionFailedError, "Unable to parse servers entry from router #{ router_address } with record #{ record } (#{ e.message })."
+        end
+
+        def parse_ttl(record, router_address)
+          expires = record.properties[:ttl] * 1000 + Time.now.to_i
+        rescue => e
+          raise Neo4j::Core::CypherSession::CypherError::ConnectionFailedError, "Unable to parse TTL entry from router #{ router_address } with record #{ record } (#{ e.message })."
+        end
+
+        private
+
+        def call_available_routing_procedure(session)
+          Neo4j::Transaction.run(session) do |tx|
+            if session.adaptor.server.version <=> Gem::Version.new('3.2.0') >= 0
+              tx.query(CALL_GET_ROUTING_TABLE, { context: @routing_context })
+            else
+              tx.query(CALL_GET_SERVERS)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/adaptors/single_connection.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/single_connection.rb
@@ -7,9 +7,9 @@ module Neo4j
     class CypherSession
       module Adaptors
         class SingleConnection < Bolt
-          def initialize(tcp_client)
+          def initialize(connection)
             @options = {}
-            @tcp_client = tcp_client
+            @tcp_client = connection.client
           end
 
           def connect; end

--- a/lib/neo4j/core/cypher_session/adaptors/single_connection.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/single_connection.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'neo4j/core/cypher_session/adaptors/bolt'
+
+module Neo4j
+  module Core
+    class CypherSession
+      module Adaptors
+        class SingleConnection < Bolt
+          def initialize(tcp_client)
+            @options = {}
+            @tcp_client = tcp_client
+          end
+
+          def connect; end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/responses/bolt_routing.rb
+++ b/lib/neo4j/core/cypher_session/responses/bolt_routing.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'neo4j/core/cypher_session/responses/bolt'
+
+module Neo4j
+  module Core
+    class CypherSession
+      module Responses
+        class BoltRouting < Bolt
+          def initialize(queries, client, flush_messages_proc, options = {})
+            @client = client
+            super(queries, flush_messages_proc, options)
+          end
+
+          private
+
+          def extract_message_groups(flush_messages_proc)
+            fields_messages = flush_messages_proc.call(@client)
+
+            validate_message_type!(fields_messages[0], :success)
+
+            result_messages = []
+            messages = nil
+
+            loop do
+              messages = flush_messages_proc.call(@client)
+              next if messages.nil?
+              break if messages[0].type == :success
+              result_messages.concat(messages)
+            end
+
+            [fields_messages[0].args[0]['fields'],
+             result_messages,
+             messages]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/core/cypher_session/transactions/bolt_routing.rb
+++ b/lib/neo4j/core/cypher_session/transactions/bolt_routing.rb
@@ -10,24 +10,23 @@ module Neo4j
           attr_accessor :access_mode, :connection
 
           def initialize(*args)
-            @access_mode = :write
-            @connection = nil
+            reset!
 
             super
+          end
 
+          def begin
             tx_query('BEGIN') if root?
           end
 
           def commit
             tx_query('COMMIT') if root?
-            @connection.release
-            @connection = nil
+            reset!
           end
 
           def delete
             tx_query('ROLLBACK')
-            @connection.release
-            @connection = nil
+            reset!
           end
 
           def started?
@@ -35,6 +34,12 @@ module Neo4j
           end
 
           private
+
+          def reset!
+            @access_mode = :write
+            @connection.release if @connection
+            @connection = nil
+          end
 
           def tx_query(cypher)
             query = Adaptors::Base::Query.new(cypher, {}, cypher)

--- a/lib/neo4j/core/cypher_session/transactions/bolt_routing.rb
+++ b/lib/neo4j/core/cypher_session/transactions/bolt_routing.rb
@@ -7,9 +7,10 @@ module Neo4j
     class CypherSession
       module Transactions
         class BoltRouting < Base
-          attr_accessor :connection
+          attr_accessor :access_mode, :connection
 
           def initialize(*args)
+            @access_mode = :write
             @connection = nil
 
             super
@@ -19,11 +20,13 @@ module Neo4j
 
           def commit
             tx_query('COMMIT') if root?
+            @connection.release
             @connection = nil
           end
 
           def delete
             tx_query('ROLLBACK')
+            @connection.release
             @connection = nil
           end
 

--- a/lib/neo4j/core/cypher_session/transactions/bolt_routing.rb
+++ b/lib/neo4j/core/cypher_session/transactions/bolt_routing.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'neo4j/core/cypher_session/transactions'
+
+module Neo4j
+  module Core
+    class CypherSession
+      module Transactions
+        class BoltRouting < Base
+          attr_accessor :connection
+
+          def initialize(*args)
+            @connection = nil
+
+            super
+
+            tx_query('BEGIN') if root?
+          end
+
+          def commit
+            tx_query('COMMIT') if root?
+            @connection = nil
+          end
+
+          def delete
+            tx_query('ROLLBACK')
+            @connection = nil
+          end
+
+          def started?
+            true
+          end
+
+          private
+
+          def tx_query(cypher)
+            query = Adaptors::Base::Query.new(cypher, {}, cypher)
+            adaptor.send(:query_set, self, [query], skip_instrumentation: true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/neo4j-core.gemspec
+++ b/neo4j-core.gemspec
@@ -31,6 +31,8 @@ DESCRIPTION
   }
 
   s.add_dependency('activesupport', '>= 4.0')
+  s.add_dependency('concurrent-ruby', '>= 1.1.0.pre2')
+  s.add_dependency('concurrent-ruby-edge', '>= 0.4.0.pre1')
   s.add_dependency('faraday', '>= 0.9.0')
   s.add_dependency('faraday_middleware', '>= 0.10.0')
   s.add_dependency('faraday_middleware-multi_json')
@@ -39,7 +41,6 @@ DESCRIPTION
   s.add_dependency('multi_json')
   s.add_dependency('net_tcp_client', '>= 2.0.1')
   s.add_dependency('typhoeus', '>= 1.1.2')
-  s.add_dependency('connection_pool', '>= 2.0.0')
 
   s.add_development_dependency('dryspec')
   s.add_development_dependency('neo4j-rake_tasks', '>= 0.3.0')

--- a/neo4j-core.gemspec
+++ b/neo4j-core.gemspec
@@ -31,8 +31,8 @@ DESCRIPTION
   }
 
   s.add_dependency('activesupport', '>= 4.0')
-  s.add_dependency('concurrent-ruby', '>= 1.1.0.pre2')
-  s.add_dependency('concurrent-ruby-edge', '>= 0.4.0.pre1')
+  s.add_dependency('concurrent-ruby', '>= 1.1')
+  s.add_dependency('concurrent-ruby-edge', '>= 0.4')
   s.add_dependency('faraday', '>= 0.9.0')
   s.add_dependency('faraday_middleware', '>= 0.10.0')
   s.add_dependency('faraday_middleware-multi_json')

--- a/neo4j-core.gemspec
+++ b/neo4j-core.gemspec
@@ -39,6 +39,7 @@ DESCRIPTION
   s.add_dependency('multi_json')
   s.add_dependency('net_tcp_client', '>= 2.0.1')
   s.add_dependency('typhoeus', '>= 1.1.2')
+  s.add_dependency('connection_pool', '>= 2.0.0')
 
   s.add_development_dependency('dryspec')
   s.add_development_dependency('neo4j-rake_tasks', '>= 0.3.0')


### PR DESCRIPTION
Fixes #322.

This pull introduces/changes:
* **Support for `bolt+routing`.** The `bolt+routing` protocol is necessary to connect to Neo4j Enterprise Causal Clusters. This PR adds support for its load-balancing and service discovery features, which are mostly... er... bolted onto the core Bolt protocol.

Caveats:
* **Tests needed.** It's in desperate need of some unit tests, but we've been using it in production at <https://ignota.com/> quite happily for a little over a week now.
* **Rubocop cleanup needed.** Shouldn't be too taxing.
* **Design up for grabs!** There are divergences with patterns used elsewhere in the gem, some intentional and some not-so-; this is my first time really digging deeply into its architecture, so I'm happy to entertain conversations about whether a better design could be arrived at.

Grateful as always for your thoughts and comments! Glad to be able to give something back to a project that's been invaluable to me these past few months. 💖

P.S.: Let me know if I can help set up a dev environment with Neo4j EE! Don't want you to have to go into it sight unseen.


Pings:
@cheerfulstoic
@subvertallchris
