### PR TITLE
Implementing `.where_or` method to `Neo4j::Core::Query`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [9.1.0] - 2019-01-21
+
+### Added
+
+- Added `.where_or` method so that we can have logical `OR` conditions in `WHERE` clause
+
 ## [9.0.0] - 2018-12-20
 
 ### Changed

--- a/lib/neo4j/core/query.rb
+++ b/lib/neo4j/core/query.rb
@@ -164,7 +164,7 @@ module Neo4j
       # DETACH DELETE clause
       # @return [Query]
 
-      METHODS = %w[start match optional_match call using where where_or create create_unique merge set on_create_set on_match_set remove unwind delete detach_delete with with_distinct return order skip limit] # rubocop:disable Metrics/LineLength
+      METHODS = %w[start match optional_match call using where create create_unique merge set on_create_set on_match_set remove unwind delete detach_delete with with_distinct return order skip limit] # rubocop:disable Metrics/LineLength
       BREAK_METHODS = %(with with_distinct call)
 
       CLAUSIFY_CLAUSE = proc { |method| const_get(method.to_s.split('_').map(&:capitalize).join + 'Clause') }
@@ -196,6 +196,12 @@ module Neo4j
       # Cypher NOT() function
       def where_not(*args)
         build_deeper_query(WhereClause, args, not: true)
+      end
+
+      # Works the same as the #where method, but the clause is surrounded by a
+      # Cypher NOT() function
+      def where_or(*args)
+        build_deeper_query(WhereClause, args, or: true)
       end
 
       # Works the same as the #set method, but when given a nested array it will set properties rather than setting entire objects

--- a/lib/neo4j/core/query.rb
+++ b/lib/neo4j/core/query.rb
@@ -164,7 +164,7 @@ module Neo4j
       # DETACH DELETE clause
       # @return [Query]
 
-      METHODS = %w[start match optional_match call using where create create_unique merge set on_create_set on_match_set remove unwind delete detach_delete with with_distinct return order skip limit] # rubocop:disable Metrics/LineLength
+      METHODS = %w[start match optional_match call using where where_or create create_unique merge set on_create_set on_match_set remove unwind delete detach_delete with with_distinct return order skip limit] # rubocop:disable Metrics/LineLength
       BREAK_METHODS = %(with with_distinct call)
 
       CLAUSIFY_CLAUSE = proc { |method| const_get(method.to_s.split('_').map(&:capitalize).join + 'Clause') }

--- a/lib/neo4j/core/query.rb
+++ b/lib/neo4j/core/query.rb
@@ -198,8 +198,7 @@ module Neo4j
         build_deeper_query(WhereClause, args, not: true)
       end
 
-      # Works the same as the #where method, but the clause is surrounded by a
-      # Cypher NOT() function
+      # Works the same as the #where method, but the clauses are connected with OR
       def where_or(*args)
         build_deeper_query(WhereClause, args, or: true)
       end

--- a/lib/neo4j/core/query_clauses.rb
+++ b/lib/neo4j/core/query_clauses.rb
@@ -275,17 +275,15 @@ module Neo4j
         end
 
         class << self
-          # rubocop:disable Lint/UselessAssignment
           def clause_strings(clauses)
             condition_string = clauses.each_with_index.inject('') do |str, (clause, inx)|
               cond = Array(clause.value).map do |v|
                 (clause.options[:not] ? 'NOT' : '') + (v.to_s.match(PAREN_SURROUND_REGEX) ? v.to_s : "(#{v})")
               end.first
-              str += (connector(clauses, inx) + cond)
+              str + (connector(clauses, inx) + cond)
             end
             Array(condition_string)
           end
-          # rubocop:enable Lint/UselessAssignment
 
           def connector(clauses, inx)
             if inx.zero?

--- a/lib/neo4j/core/query_clauses.rb
+++ b/lib/neo4j/core/query_clauses.rb
@@ -14,6 +14,7 @@ module Neo4j
         COMMA_SPACE = ', '
         AND = ' AND '
         PRETTY_NEW_LINE = "\n  "
+        OR = ' OR '
 
         attr_accessor :params, :arg
         attr_reader :options, :param_vars_added
@@ -329,6 +330,19 @@ module Neo4j
             else
               super
             end
+          end
+        end
+      end
+
+      class WhereOrClause < WhereClause
+        def hash_key_value_string(key, value, previous_keys)
+          string = super
+          string.gsub(AND, OR)
+        end
+
+        class << self
+          def clause_join
+            Clause::OR
           end
         end
       end

--- a/lib/neo4j/core/query_clauses.rb
+++ b/lib/neo4j/core/query_clauses.rb
@@ -275,21 +275,23 @@ module Neo4j
         end
 
         class << self
+          # rubocop:disable Lint/UselessAssignment
           def clause_strings(clauses)
             condition_string = clauses.each_with_index.inject('') do |str, (clause, inx)|
               cond = Array(clause.value).map do |v|
                 (clause.options[:not] ? 'NOT' : '') + (v.to_s.match(PAREN_SURROUND_REGEX) ? v.to_s : "(#{v})")
               end.first
-              str += (connector(clauses, inx) + cond) 
+              str += (connector(clauses, inx) + cond)
             end
             Array(condition_string)
           end
+          # rubocop:enable Lint/UselessAssignment
 
           def connector(clauses, inx)
-            if inx == 0
+            if inx.zero?
               ''
             else
-              clauses[inx].options[:or] && clauses[inx-1].options[:or] ? Clause::OR : Clause::AND
+              clauses[inx].options[:or] && clauses[inx - 1].options[:or] ? Clause::OR : Clause::AND
             end
           end
 

--- a/lib/neo4j/core/query_clauses.rb
+++ b/lib/neo4j/core/query_clauses.rb
@@ -280,7 +280,7 @@ module Neo4j
               cond = Array(clause.value).map do |v|
                 (clause.options[:not] ? 'NOT' : '') + (v.to_s.match(PAREN_SURROUND_REGEX) ? v.to_s : "(#{v})")
               end.first
-              str + (connector(clauses, inx) + cond)
+              str + connector(clauses, inx) + cond
             end
             Array(condition_string)
           end

--- a/lib/neo4j/core/version.rb
+++ b/lib/neo4j/core/version.rb
@@ -1,5 +1,5 @@
 module Neo4j
   module Core
-    VERSION = '9.0.0'
+    VERSION = '9.1.0'
   end
 end

--- a/spec/neo4j/core/query_spec.rb
+++ b/spec/neo4j/core/query_spec.rb
@@ -477,7 +477,7 @@ describe Neo4j::Core::Query do
     end
 
     describe ".where_or('q.age > 30').where_or('q.age < 50')" do
-      it_generates '"WHERE (q.age > 30) OR (q.age < 50)'
+      it_generates 'WHERE (q.age > 30) OR (q.age < 50)'
     end
 
     describe ".where_or('q.age > 30').where_not('q.age < 50')" do
@@ -505,7 +505,7 @@ describe Neo4j::Core::Query do
     end  
 
     describe ".where_or(q: {age: 20, name: 'Bacon'}).where_not(q: {age: 30, name: 'Chunky'})" do
-      it_generates 'WHERE (q.age = {q_age} OR q.name = {q_name}) AND NOT(q.age = {q_age2} OR q.name = {q_name2})', q_age2: 30, q_name2: 'Chunky', q_age: 20, q_name: 'Bacon'
+      it_generates 'WHERE (q.age = {q_age} OR q.name = {q_name}) AND NOT(q.age = {q_age2} AND q.name = {q_name2})', q_age2: 30, q_name2: 'Chunky', q_age: 20, q_name: 'Bacon'
     end
 
     describe '.where_or(q: {name: /Chunky.*/i})' do

--- a/spec/neo4j/core/query_spec.rb
+++ b/spec/neo4j/core/query_spec.rb
@@ -453,7 +453,6 @@ describe Neo4j::Core::Query do
       it_generates 'WHERE NOT(q.name =~ {q_name})', q_name: '(?i)Brian.*'
     end
 
-
     describe ".where('q.age > 10').where_not('q.age > 30')" do
       it_generates 'WHERE (q.age > 10) AND NOT(q.age > 30)'
     end
@@ -462,6 +461,50 @@ describe Neo4j::Core::Query do
       it_generates 'WHERE NOT(q.age > 30) AND (q.age > 10)'
     end
   end
+
+
+  describe '#where_or' do
+    describe '.where_or()' do
+      it_generates ''
+    end
+
+    describe '.where_or({})' do
+      it_generates ''
+    end
+
+    describe ".where_or('q.age > 30')" do
+      it_generates 'WHERE (q.age > 30)'
+    end
+
+    describe ".where_or('q.age' => 30)" do
+      it_generates 'WHERE (q.age = {q_age})', q_age: 30
+    end
+
+    describe ".where_or('q.age IN ?', [30, 32, 34])" do
+      it_generates 'WHERE (q.age IN {question_mark_param})', question_mark_param: [30, 32, 34]
+    end
+
+    describe ".where_or(q: {age: 30, name: 'Chunky'})" do
+      it_generates 'WHERE (q.age = {q_age} OR q.name = {q_name})', q_age: 30, q_name: 'Chunky'
+    end
+
+    describe '.where_or(q: {name: /Chunky.*/i})' do
+      it_generates 'WHERE (q.name =~ {q_name})', q_name: '(?i)Chunky.*'
+    end
+
+    describe ".where('q.age > 10').where_or('q.age > 30')" do
+      it_generates 'WHERE (q.age > 10) AND (q.age > 30)'
+    end
+
+    describe ".where_or('q.age > 30').where('q.age > 10')" do
+      it_generates 'WHERE (q.age > 30) AND (q.age > 10)'
+    end
+
+    describe ".where_or({q: {age: 30}}, '(q)->[:ABC]->()')" do
+      it_generates 'WHERE (q.age = {q_age}) OR (q)->[:ABC]->()', q_age: 30
+    end
+  end
+
 
   describe '#match_nodes' do
     context 'one node object' do

--- a/spec/neo4j/core/query_spec.rb
+++ b/spec/neo4j/core/query_spec.rb
@@ -509,8 +509,8 @@ describe Neo4j::Core::Query do
       it_generates 'WHERE (q.age = {q_age} OR q.name = {q_name}) AND NOT(q.age = {q_age2} AND q.name = {q_name2})', q_age2: 30, q_name2: 'Chunky', q_age: 20, q_name: 'Bacon'
     end
 
-    describe '.where_or(q: {name: /Chunky.*/i})' do
-      it_generates 'WHERE (q.name =~ {q_name})', q_name: '(?i)Chunky.*'
+    describe ".where_or(q: {age: 20, name: 'Bacon'})" do
+      it_generates 'WHERE (q.age = {q_age} OR q.name = {q_name})', q_age: 20, q_name: 'Bacon'
     end
 
     describe ".where('q.age > 10').where_or('q.age > 30')" do

--- a/spec/neo4j/core/query_spec.rb
+++ b/spec/neo4j/core/query_spec.rb
@@ -502,7 +502,7 @@ describe Neo4j::Core::Query do
 
     describe ".where(q: {age: 20, name: 'Bacon'}).where_or(q: {age: 30, name: 'Chunky'}).where_not(q: {active: false})" do
       it_generates 'WHERE (q.age = {q_age} AND q.name = {q_name}) AND (q.age = {q_age2} OR q.name = {q_name2}) AND NOT(q.active = {q_active})',
-        q_age2: 30, q_name2: 'Chunky', q_age: 20, q_name: 'Bacon', q_active: false
+                   q_age2: 30, q_name2: 'Chunky', q_age: 20, q_name: 'Bacon', q_active: false
     end  
 
     describe ".where_or(q: {age: 20, name: 'Bacon'}).where_not(q: {age: 30, name: 'Chunky'})" do

--- a/spec/neo4j/core/query_spec.rb
+++ b/spec/neo4j/core/query_spec.rb
@@ -503,7 +503,7 @@ describe Neo4j::Core::Query do
     describe ".where(q: {age: 20, name: 'Bacon'}).where_or(q: {age: 30, name: 'Chunky'}).where_not(q: {active: false})" do
       it_generates 'WHERE (q.age = {q_age} AND q.name = {q_name}) AND (q.age = {q_age2} OR q.name = {q_name2}) AND NOT(q.active = {q_active})',
                    q_age2: 30, q_name2: 'Chunky', q_age: 20, q_name: 'Bacon', q_active: false
-    end  
+    end
 
     describe ".where_or(q: {age: 20, name: 'Bacon'}).where_not(q: {age: 30, name: 'Chunky'})" do
       it_generates 'WHERE (q.age = {q_age} OR q.name = {q_name}) AND NOT(q.age = {q_age2} AND q.name = {q_name2})', q_age2: 30, q_name2: 'Chunky', q_age: 20, q_name: 'Bacon'

--- a/spec/neo4j/core/query_spec.rb
+++ b/spec/neo4j/core/query_spec.rb
@@ -501,7 +501,8 @@ describe Neo4j::Core::Query do
     end
 
     describe ".where(q: {age: 20, name: 'Bacon'}).where_or(q: {age: 30, name: 'Chunky'}).where_not(q: {active: false})" do
-      it_generates 'WHERE (q.age = {q_age} AND q.name = {q_name}) AND (q.age = {q_age2} OR q.name = {q_name2}) AND NOT(q.active = {q_active})', q_age2: 30, q_name2: 'Chunky', q_age: 20, q_name: 'Bacon', q_active: false
+      it_generates 'WHERE (q.age = {q_age} AND q.name = {q_name}) AND (q.age = {q_age2} OR q.name = {q_name2}) AND NOT(q.active = {q_active})',
+        q_age2: 30, q_name2: 'Chunky', q_age: 20, q_name: 'Bacon', q_active: false
     end  
 
     describe ".where_or(q: {age: 20, name: 'Bacon'}).where_not(q: {age: 30, name: 'Chunky'})" do


### PR DESCRIPTION
Fixes #

This pull introduces:
 * introducing `.where_or` method to `Neo4j::Core::Query`

eg.

`Neo4j::Core::Query.new.where_or(q: {age: 30, name: 'Chunky'})`

would generate cypher like 
`WHERE (q.age = {q_age} OR q.name = {q_name})`



Pings:
@klobuczek 