### PR TITLE
Allow specifying planner and runtime for neo4j queries

### DIFF
--- a/lib/neo4j/core/query.rb
+++ b/lib/neo4j/core/query.rb
@@ -350,7 +350,12 @@ module Neo4j
           cypher_parts.join(join_string).tap(&:strip!)
         end.join(join_string)
 
-        cypher_string = "CYPHER #{@options[:parser]} #{cypher_string}" if @options[:parser]
+        cypher_query_options = []
+        cypher_query_options << @options[:parser] if @options[:parser]
+        cypher_query_options << "planner=#{@options[:planner]}" if @options[:planner]
+        cypher_query_options << "runtime=#{@options[:runtime]}" if @options[:runtime]
+        cypher_string = "CYPHER #{cypher_query_options.join(' ')} #{cypher_string}" unless cypher_query_options.empty?
+
         cypher_string.tap(&:strip!)
       end
       alias cypher to_cypher

--- a/spec/neo4j/core/query_spec.rb
+++ b/spec/neo4j/core/query_spec.rb
@@ -78,17 +78,42 @@ describe Neo4j::Core::Query do
   end
 
   describe 'options' do
-    let(:query) { Neo4j::Core::Query.new(parser: 2.0) }
+    let(:query_options) { { parser: 2.0, planner: 'cost', runtime: 'compiled' } }
+    let(:query) { Neo4j::Core::Query.new(query_options) }
 
-    it 'should generate a per-query cypher parser version' do
-      expect(query.to_cypher).to eq('CYPHER 2.0')
+    it 'should generate a per-query cypher parser version, planner and runtime' do
+      expect(query.to_cypher).to eq('CYPHER 2.0 planner=cost runtime=compiled')
+    end
+
+    describe 'parser only' do
+      let(:query_options) { { parser: 2.0 } }
+
+      it 'should generate a per-query cypher parser version' do
+        expect(query.to_cypher).to eq('CYPHER 2.0')
+      end
+    end
+
+    describe 'planner only' do
+      let(:query_options) { { planner: 'cost' } }
+
+      it 'should generate a per-query cypher planner' do
+        expect(query.to_cypher).to eq('CYPHER planner=cost')
+      end
+    end
+
+    describe 'runtime only' do
+      let(:query_options) { { runtime: 'compiled' } }
+
+      it 'should generate a per-query cypher runtime' do
+        expect(query.to_cypher).to eq('CYPHER runtime=compiled')
+      end
     end
 
     describe 'subsequent call' do
       let(:query) { super().match('q:Person') }
 
       it 'should combine the parser version with the rest of the query' do
-        expect(query.to_cypher).to eq('CYPHER 2.0 MATCH q:Person')
+        expect(query.to_cypher).to eq('CYPHER 2.0 planner=cost runtime=compiled MATCH q:Person')
       end
     end
   end


### PR DESCRIPTION
### This pull introduces
You can now specify planner and/or runtime for neo4j queries (https://neo4j.com/docs/cypher-manual/current/query-tuning/query-options/).

```ruby
Neo4j::Core::Query.new(parser: 2.0, planner: 'cost', runtime: 'compiled')
```

Pings:
@cheerfulstoic
@subvertallchris
