### PR TITLE
Fix ordering of ON MATCH / ON CREATE and SET

### DIFF
--- a/lib/neo4j/core/query.rb
+++ b/lib/neo4j/core/query.rb
@@ -164,7 +164,7 @@ module Neo4j
       # DETACH DELETE clause
       # @return [Query]
 
-      METHODS = %w[start match optional_match call using where create create_unique merge set on_create_set on_match_set remove unwind delete detach_delete with with_distinct return order skip limit] # rubocop:disable Metrics/LineLength
+      METHODS = %w[start match optional_match call using where create create_unique merge on_create_set on_match_set set remove unwind delete detach_delete with with_distinct return order skip limit] # rubocop:disable Metrics/LineLength
       BREAK_METHODS = %(with with_distinct call)
 
       CLAUSIFY_CLAUSE = proc { |method| const_get(method.to_s.split('_').map(&:capitalize).join + 'Clause') }

--- a/spec/neo4j/core/query_spec.rb
+++ b/spec/neo4j/core/query_spec.rb
@@ -855,6 +855,11 @@ describe Neo4j::Core::Query do
       it_generates 'ON CREATE SET n = {name: "Brian"}'
     end
 
+    # ON CREATE SET must come before SET (and immediately after MERGE) or the cypher is invalid
+    describe '.on_create_set(n: { name: "Brian" }).set(n: { age: 30 })' do
+      it_generates 'ON CREATE SET n.`name` = {setter_n_name} SET n.`age` = {setter_n_age}', setter_n_name: 'Brian', setter_n_age: 30
+    end
+
     describe '.on_create_set(n: {})' do
       it_generates '', {}
     end

--- a/spec/neo4j/core/query_spec.rb
+++ b/spec/neo4j/core/query_spec.rb
@@ -882,6 +882,11 @@ describe Neo4j::Core::Query do
       it_generates 'ON MATCH SET n = {name: "Brian"}'
     end
 
+    # ON MATCH SET must come before SET (and immediately after MERGE) or the cypher is invalid
+    describe '.on_match_set(n: { name: "Brian" }).set(n: { age: 30 })' do
+      it_generates 'ON MATCH SET n.`name` = {setter_n_name} SET n.`age` = {setter_n_age}', setter_n_name: 'Brian', setter_n_age: 30
+    end
+
     describe '.on_match_set(n: {})' do
       it_generates '', {}
     end


### PR DESCRIPTION
Fixes #332 

This pull introduces/changes:
 * ON MATCH SET will be placed before SET in generated cypher
 * ON CREATE SET will be placed before SET in generated cypher

