### PR TITLE
Escape strings in RemoveClause

### DIFF
--- a/lib/neo4j/core/query_clauses.rb
+++ b/lib/neo4j/core/query_clauses.rb
@@ -643,9 +643,7 @@ module Neo4j
           case value
           when /^:/
             "#{key}:`#{value[1..-1]}`"
-          when String
-            "#{key}.#{value}"
-          when Symbol
+          when String, Symbol
             "#{key}:`#{value}`"
           when Array
             value.map do |v|


### PR DESCRIPTION
Currently in RemoveClause only symbols are escaped with backticks, meaning that using `.remove` will fail on labels with special characters. This can be encountered with a namespaced label name, such as `MyModule::MyThing`.

This just makes the switch process strings and symbols in the same block.

