### PR TITLE
Don't fail schema inspection when full text indexes exist

### DIFF
--- a/lib/neo4j/core/cypher_session/adaptors/schema.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/schema.rb
@@ -14,18 +14,24 @@ module Neo4j
             result = query(session, 'CALL db.indexes()', {}, skip_instrumentation: true)
 
             result.map do |row|
-              label, property = row.description.match(/INDEX ON :([^\(]+)\(([^\)]+)\)/)[1, 2]
+              match = row.description.match(/INDEX ON :([^\(]+)\(([^\)]+)\)/)
+              next unless match
+
+              label, property = match[1, 2]
               {type: row.type.to_sym, label: label.to_sym, properties: [property.to_sym], state: row.state.to_sym}
-            end
+            end.compact
           end
 
           def constraints(session)
             result = query(session, 'CALL db.indexes()', {}, skip_instrumentation: true)
 
             result.select { |row| row.type == 'node_unique_property' }.map do |row|
-              label, property = row.description.match(/INDEX ON :([^\(]+)\(([^\)]+)\)/)[1, 2]
+              match = row.description.match(/INDEX ON :([^\(]+)\(([^\)]+)\)/)
+              next unless match
+
+              label, property = match[1, 2]
               {type: :uniqueness, label: label.to_sym, properties: [property.to_sym]}
-            end
+            end.compact
           end
         end
       end


### PR DESCRIPTION
This pull introduces/changes:
 *  Using Cypher queries instead of `/db/data/schema/index` endpoint for getting indexes and constraints in Neo4j >= 3.0.0 (since addition of the `CALL` clause)
 * Schema validation doesn't fail when full text indexes exist by ignoring such indexes

This PR is needed to allow using `neo4j-core` when full text indexes exist, without this PR schema validation fails as they appear as `INDEX ON NODE:Label(key)` instead of `INDEX ON :Label(key)` in `db.indexes` (more of the discussion: https://gitter.im/neo4jrb/neo4j?at=5e1efa848b53f6190ab79919).

This PR doesn't add any additional support for such indexes.